### PR TITLE
Refactor JSON handling code to use Jsoncpp library instead of Qt's QJson APIs

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -132,7 +132,7 @@ INCLUDEPATH += $${CHROMIUM_SRC_DIR}
 
 DEFINES += PRELOADMANAGER_ENABLED
 
-QMAKE_CXXFLAGS += -fno-rtti -fno-exceptions -Wall -fpermissive -funwind-tables
+QMAKE_CXXFLAGS += -fno-rtti -Wall -fpermissive -funwind-tables
 QMAKE_CXXFLAGS += -std=c++14
 QMAKE_LFLAGS += -rdynamic
 

--- a/common.pri
+++ b/common.pri
@@ -121,7 +121,7 @@ VPATH += \
     ./src/util \
     ./src/webos
 
-PKGCONFIG += glib-2.0 libxml-2.0
+PKGCONFIG += glib-2.0 libxml-2.0 jsoncpp
 
 INCLUDEPATH += $$VPATH
 

--- a/src/agl/WebAppManagerServiceAGL.cpp
+++ b/src/agl/WebAppManagerServiceAGL.cpp
@@ -222,7 +222,7 @@ bool WebAppManagerServiceAGL::startService()
       pthread_t thread_id;
       if( pthread_create( &thread_id , nullptr,  run_socket, socket_.get()) < 0) {
           perror("could not create thread");
-          fprintf(stderr, "Coudlnt create thread...\r\n");
+          fprintf(stderr, "Couldnt create thread...\r\n");
           return false;
       }
     }
@@ -318,8 +318,8 @@ void WebAppManagerServiceAGL::launchStartupAppFromConfig()
 
 void WebAppManagerServiceAGL::launchStartupAppFromURL()
 {
-fprintf(stderr, "WebAppManagerServiceAGL::launchStartupAppFromURL\r\n");
-fprintf(stderr, "    url: %s\r\n", startup_app_uri_.c_str());
+    fprintf(stderr, "WebAppManagerServiceAGL::launchStartupAppFromURL\r\n");
+    fprintf(stderr, "    url: %s\r\n", startup_app_uri_.c_str());
     QJsonObject obj;
     obj["id"] = QJsonValue((const char*)startup_app_id_.c_str());
     obj["version"] = QJsonValue("1.0");

--- a/src/agl/WebAppManagerServiceAGL.cpp
+++ b/src/agl/WebAppManagerServiceAGL.cpp
@@ -13,9 +13,10 @@
 #include <sstream>
 #include <pthread.h>
 
+#include <json/value.h>
 #include <libxml/parser.h>
 
-#include <QJsonDocument>
+#include "JsonHelper.h"
 
 class WamSocketLockFile {
 public:
@@ -286,17 +287,17 @@ void WebAppManagerServiceAGL::launchStartupAppFromConfig()
     fprintf(stderr, "icon: %s\r\n", icon);
 
 
-    QJsonObject obj;
-    obj["id"] = QJsonValue((const char*)id);
-    obj["version"] = QJsonValue((const char*)version);
-    obj["vendor"] = QJsonValue((const char*)author);
-    obj["type"] = QJsonValue("web");
-    obj["main"] = QJsonValue((const char*)content);
-    obj["title"] = QJsonValue((const char*)name);
-    obj["uiRevision"] = QJsonValue("2");
-    obj["icon"] = QJsonValue((const char*)icon);
-    obj["folderPath"] = QJsonValue(startup_app_uri_.c_str());
-    obj["surfaceId"] = QJsonValue(startup_app_surface_id_);
+    Json::Value obj(Json::objectValue);
+    obj["id"] = (const char*)id;
+    obj["version"] = (const char*)version;
+    obj["vendor"] = (const char*)author;
+    obj["type"] = "web";
+    obj["main"] = (const char*)content;
+    obj["title"] = (const char*)name;
+    obj["uiRevision"] = "2";
+    obj["icon"] = (const char*)icon;
+    obj["folderPath"] = startup_app_uri_.c_str();
+    obj["surfaceId"] = startup_app_surface_id_;
 
     xmlFree(id);
     xmlFree(version);
@@ -307,10 +308,10 @@ void WebAppManagerServiceAGL::launchStartupAppFromConfig()
     xmlFree(icon);
     xmlFreeDoc(doc);
 
-    QJsonDocument appDoc(obj);
-    std::string appDesc = appDoc.toJson(QJsonDocument::Compact).toStdString();
+    std::string appDesc;
+    dumpJsonToString(obj, appDesc);
     std::string params;
-    std::string app_id = obj["id"].toString().toStdString();
+    std::string app_id = obj["id"].asString();
     int errCode = 0;
     std::string errMsg;
     WebAppManagerService::onLaunch(appDesc, params, app_id, errCode, errMsg);
@@ -320,22 +321,22 @@ void WebAppManagerServiceAGL::launchStartupAppFromURL()
 {
     fprintf(stderr, "WebAppManagerServiceAGL::launchStartupAppFromURL\r\n");
     fprintf(stderr, "    url: %s\r\n", startup_app_uri_.c_str());
-    QJsonObject obj;
-    obj["id"] = QJsonValue((const char*)startup_app_id_.c_str());
-    obj["version"] = QJsonValue("1.0");
-    obj["vendor"] = QJsonValue("some vendor");
-    obj["type"] = QJsonValue("web");
-    obj["main"] = QJsonValue((const char*)startup_app_uri_.c_str());
-    obj["title"] = QJsonValue("webapp");
-    obj["uiRevision"] = QJsonValue("2");
-    //obj["icon"] = QJsonValue((const char*)icon);
-    //obj["folderPath"] = QJsonValue(startup_app_.c_str());
-    obj["surfaceId"] = QJsonValue(startup_app_surface_id_);
+    Json::Value obj(Json::objectValue);
+    obj["id"] = (const char*)startup_app_id_.c_str();
+    obj["version"] = "1.0";
+    obj["vendor"] = "some vendor";
+    obj["type"] = "web";
+    obj["main"] = (const char*)startup_app_uri_.c_str();
+    obj["title"] = "webapp";
+    obj["uiRevision"] = "2";
+    //obj["icon"] = (const char*)icon;
+    //obj["folderPath"] = startup_app_.c_str();
+    obj["surfaceId"] = startup_app_surface_id_;
 
-    QJsonDocument appDoc(obj);
-    std::string appDesc = appDoc.toJson(QJsonDocument::Compact).toStdString();
+    std::string appDesc;
+    dumpJsonToString(obj, appDesc);
     std::string params;
-    std::string app_id = obj["id"].toString().toStdString();
+    std::string app_id = obj["id"].asString();
     int errCode = 0;
     std::string errMsg;
 
@@ -345,58 +346,57 @@ void WebAppManagerServiceAGL::launchStartupAppFromURL()
     WebAppManagerService::onLaunch(appDesc, params, app_id, errCode, errMsg);
 }
 
-QJsonObject WebAppManagerServiceAGL::launchApp(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::launchApp(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::killApp(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::killApp(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::logControl(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::logControl(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::setInspectorEnable(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::setInspectorEnable(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::closeAllApps(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::closeAllApps(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-
-QJsonObject WebAppManagerServiceAGL::discardCodeCache(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::discardCodeCache(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::listRunningApps(QJsonObject request, bool subscribed)
+Json::Value WebAppManagerServiceAGL::listRunningApps(const Json::Value &request, bool subscribed)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::closeByProcessId(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::closeByProcessId(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::getWebProcessSize(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::getWebProcessSize(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::clearBrowsingData(QJsonObject request)
+Json::Value WebAppManagerServiceAGL::clearBrowsingData(const Json::Value &request)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }
 
-QJsonObject WebAppManagerServiceAGL::webProcessCreated(QJsonObject request, bool subscribed)
+Json::Value WebAppManagerServiceAGL::webProcessCreated(const Json::Value &request, bool subscribed)
 {
-    return QJsonObject();
+    return Json::Value(Json::objectValue);
 }

--- a/src/agl/WebAppManagerServiceAGL.h
+++ b/src/agl/WebAppManagerServiceAGL.h
@@ -3,8 +3,6 @@
 
 #include <memory>
 
-#include <QJsonObject>
-
 #include "WebAppManagerService.h"
 #include "Timer.h"
 
@@ -28,17 +26,17 @@ public:
 
     // WebAppManagerService
     bool startService() override;
-    QJsonObject launchApp(QJsonObject request) override;
-    QJsonObject killApp(QJsonObject request) override;
-    QJsonObject logControl(QJsonObject request) override;
-    QJsonObject setInspectorEnable(QJsonObject request) override;
-    QJsonObject closeAllApps(QJsonObject request) override;
-    QJsonObject discardCodeCache(QJsonObject request) override;
-    QJsonObject listRunningApps(QJsonObject request, bool subscribed) override;
-    QJsonObject closeByProcessId(QJsonObject request) override;
-    QJsonObject getWebProcessSize(QJsonObject request) override;
-    QJsonObject clearBrowsingData(QJsonObject request) override;
-    QJsonObject webProcessCreated(QJsonObject request, bool subscribed) override;
+    Json::Value launchApp(const Json::Value &request) override;
+    Json::Value killApp(const Json::Value &request) override;
+    Json::Value logControl(const Json::Value &request) override;
+    Json::Value setInspectorEnable(const Json::Value &request) override;
+    Json::Value closeAllApps(const Json::Value &request) override;
+    Json::Value discardCodeCache(const Json::Value &request) override;
+    Json::Value listRunningApps(const Json::Value &request, bool subscribed) override;
+    Json::Value closeByProcessId(const Json::Value &request) override;
+    Json::Value getWebProcessSize(const Json::Value &request) override;
+    Json::Value clearBrowsingData(const Json::Value &request) override;
+    Json::Value webProcessCreated(const Json::Value &request, bool subscribed) override;
 
     void triggerStartupApp();
 

--- a/src/agl/WebRuntimeAGL.cpp
+++ b/src/agl/WebRuntimeAGL.cpp
@@ -163,10 +163,10 @@ int WebAppLauncherRuntime::run(int argc, const char** argv) {
   m_role = "WebApp";
 
   if(WebAppManagerServiceAGL::instance()->isHostServiceRunning()) {
-fprintf(stderr, "WebAppLauncherRuntime::run - creating SharedBrowserProcessWebAppLauncher\r\n");
+    fprintf(stderr, "WebAppLauncherRuntime::run - creating SharedBrowserProcessWebAppLauncher\r\n");
     m_launcher = new SharedBrowserProcessWebAppLauncher();
   } else {
-fprintf(stderr, "WebAppLauncherRuntime::run - creating SingleBrowserProcessWebAppLauncher\r\n");
+    fprintf(stderr, "WebAppLauncherRuntime::run - creating SingleBrowserProcessWebAppLauncher\r\n");
     m_launcher = new SingleBrowserProcessWebAppLauncher();
   }
 

--- a/src/core/ApplicationDescription.cpp
+++ b/src/core/ApplicationDescription.cpp
@@ -21,14 +21,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include <QJsonParseError>
-#include <QJsonValue>
-#include <QVariant>
-
 #include "ApplicationDescription.h"
+#include "JsonHelper.h"
 #include "LogManager.h"
 
 bool ApplicationDescription::checkTrustLevel(std::string trustLevel)
@@ -68,13 +62,18 @@ const ApplicationDescription::WindowGroupInfo ApplicationDescription::getWindowG
     ApplicationDescription::WindowGroupInfo info;
 
     if (!m_groupWindowDesc.empty()) {
-        QJsonDocument jsonDoc = QJsonDocument::fromJson(QByteArray(m_groupWindowDesc.c_str()));
-        QJsonObject jsonObject = jsonDoc.object();
+        Json::Value json;
+        readJsonFromString(m_groupWindowDesc, json);
 
-        if (!jsonObject.value("name").isUndefined())
-            info.name = jsonObject.value("name").toString();
-        if (!jsonObject.value("owner").isUndefined())
-            info.isOwner = jsonObject.value("owner").toBool();
+        if (json.isObject()) {
+            auto name = json["name"];
+            if (name.isString())
+                info.name = QString::fromStdString(name.asString());
+
+            auto isOwner = json["owner"];
+            if (isOwner.isBool())
+                info.isOwner = isOwner.asBool();
+        }
     }
 
     return info;
@@ -84,21 +83,23 @@ const ApplicationDescription::WindowOwnerInfo ApplicationDescription::getWindowO
 {
     ApplicationDescription::WindowOwnerInfo info;
     if (!m_groupWindowDesc.empty()) {
-        QJsonDocument jsonDoc = QJsonDocument::fromJson(QByteArray(m_groupWindowDesc.c_str()));
-        QJsonObject jsonObject = jsonDoc.object();
+        Json::Value json;
+        readJsonFromString(m_groupWindowDesc, json);
 
-        if (!jsonObject.value("ownerInfo").isUndefined()) {
-            QJsonObject ownerJsonObject = jsonObject.value("ownerInfo").toObject();
-            if (!ownerJsonObject.value("allowAnonymous").isUndefined())
-                info.allowAnonymous =ownerJsonObject.value("allowAnonymous").toBool();
+        auto ownerInfo = json["ownerInfo"];
+        if (ownerInfo.isObject()) {
+            if (ownerInfo["allowAnonymous"].isBool())
+                info.allowAnonymous = ownerInfo["allowAnonymous"].asBool();
 
-            if (!ownerJsonObject.value("layers").isUndefined()) {
-                QJsonArray ownerJsonArray = ownerJsonObject.value("layers").toArray();
-
-                for (int i=0; i<ownerJsonArray.size(); i++) {
-                    QVariantMap map = ownerJsonArray[i].toObject().toVariantMap();
-                    if (!map.empty())
-                        info.layers.insert(map["name"].toString(), map["z"].toString().toInt());
+            auto layers = ownerInfo["layers"];
+            if (layers.isArray()) {
+                for (const auto &layer : layers) {
+                    auto name = layer["name"];
+                    auto zstr = layer["z"];
+                    if (name.isString() && zstr.isString()) {
+                        int z = std::stoi(zstr.asString());
+                        info.layers.insert(QString::fromStdString(name.asString()), z);
+                    }
                 }
             }
         }
@@ -111,16 +112,18 @@ const ApplicationDescription::WindowClientInfo ApplicationDescription::getWindow
 {
     ApplicationDescription::WindowClientInfo info;
     if (!m_groupWindowDesc.empty()) {
-        QJsonDocument jsonDoc = QJsonDocument::fromJson(QByteArray(m_groupWindowDesc.c_str()));
-        QJsonObject jsonObject = jsonDoc.object();
+        Json::Value json;
+        readJsonFromString(m_groupWindowDesc, json);
 
-        if (!jsonObject.value("clientInfo").isUndefined()) {
-            QJsonObject clientJsonObject = jsonObject.value("clientInfo").toObject();
-            if (!clientJsonObject.value("layer").isUndefined())
-                info.layer = clientJsonObject.value("layer").toString();
+        auto clientInfo = json["clientInfo"];
+        if (clientInfo.isObject()) {
+            auto layer = clientInfo["layer"];
+            if (layer.isString())
+                info.layer = QString::fromStdString(layer.asString());
 
-            if (!clientJsonObject.value("hint").isUndefined())
-                info.hint = clientJsonObject.value("hint").toString();
+            auto hint = clientInfo["hint"];
+            if (hint.isString())
+                info.hint = QString::fromStdString(hint.asString());
         }
     }
     return info;
@@ -128,65 +131,67 @@ const ApplicationDescription::WindowClientInfo ApplicationDescription::getWindow
 
 ApplicationDescription* ApplicationDescription::fromJsonString(const char* jsonStr)
 {
-    QJsonParseError parseError;
-    QJsonDocument jsonDoc = QJsonDocument::fromJson(QByteArray(jsonStr), &parseError);
-    if (parseError.error != QJsonParseError::NoError) {
+    Json::Value jsonObj;
+    if (!readJsonFromString(jsonStr, jsonObj)) {
         LOG_WARNING(MSGID_APP_DESC_PARSE_FAIL, 1,
                     PMLOGKFV("JSON", "%s", jsonStr), "Failed to parse JSON string");
         return 0;
     }
-    QJsonObject jsonObj = jsonDoc.object();
 
     ApplicationDescription* appDesc = new ApplicationDescription();
 
-    appDesc->m_surfaceId = jsonObj["surfaceId"].toInt();
-    appDesc->m_transparency = jsonObj["transparent"].toBool();
-    appDesc->m_vendorExtension = QJsonDocument(jsonObj["vendorExtension"].toObject()).toJson().data();
-    appDesc->m_trustLevel = jsonObj["trustLevel"].toString().toStdString();
-    appDesc->m_subType = jsonObj["subType"].toString().toStdString();
-    appDesc->m_deeplinkingParams = jsonObj["deeplinkingParams"].toString().toStdString();
-    appDesc->m_handlesRelaunch = jsonObj["handlesRelaunch"].toBool();
-    appDesc->m_defaultWindowType = jsonObj["defaultWindowType"].toString().toStdString();
-    appDesc->m_inspectable = jsonObj["inspectable"].toBool();
-    appDesc->m_containerJS = jsonObj["containerJS"].toString().toStdString();
-    appDesc->m_containerCSS = jsonObj["containerCSS"].toString().toStdString();
-    appDesc->m_enyoBundleVersion = jsonObj["enyoBundleVersion"].toString().toStdString();
-    appDesc->m_enyoVersion = jsonObj["enyoVersion"].toString().toStdString();
-    appDesc->m_version = jsonObj["version"].toString().toStdString();
-    appDesc->m_customPlugin = jsonObj["customPlugin"].toBool();
-    appDesc->m_backHistoryAPIDisabled = jsonObj["disableBackHistoryAPI"].toBool();
-    appDesc->m_groupWindowDesc = QJsonDocument(jsonObj["windowGroup"].toObject()).toJson().data();
+    appDesc->m_surfaceId = jsonObj["surfaceId"].asInt();
+    appDesc->m_transparency = jsonObj["transparent"].asBool();
+    appDesc->m_vendorExtension = jsonObj["vendorExtension"].toStyledString();
+    appDesc->m_trustLevel = jsonObj["trustLevel"].asString();
+    appDesc->m_subType = jsonObj["subType"].asString();
+    appDesc->m_deeplinkingParams = jsonObj["deeplinkingParams"].asString();
+    appDesc->m_handlesRelaunch = jsonObj["handlesRelaunch"].asBool();
+    appDesc->m_defaultWindowType = jsonObj["defaultWindowType"].asString();
+    appDesc->m_inspectable = jsonObj["inspectable"].asBool();
+    appDesc->m_containerJS = jsonObj["containerJS"].asString();
+    appDesc->m_containerCSS = jsonObj["containerCSS"].asString();
+    appDesc->m_enyoBundleVersion = jsonObj["enyoBundleVersion"].asString();
+    appDesc->m_enyoVersion = jsonObj["enyoVersion"].asString();
+    appDesc->m_version = jsonObj["version"].asString();
+    appDesc->m_customPlugin = jsonObj["customPlugin"].asBool();
+    appDesc->m_backHistoryAPIDisabled = jsonObj["disableBackHistoryAPI"].asBool();
+    appDesc->m_groupWindowDesc = jsonObj["windowGroup"].toStyledString();
 
-    if (jsonObj.contains("supportedEnyoBundleVersions")) {
-        QJsonArray versions = jsonObj["supportedEnyoBundleVersions"].toArray();
-        for (int i=0; i < versions.size(); i++)
-            appDesc->m_supportedEnyoBundleVersions.append(versions[i].toString());
+    auto supportedVersions = jsonObj["supportedEnyoBundleVersions"];
+    if (supportedVersions.isArray()) {
+        for (const Json::Value &version : supportedVersions)
+            appDesc->m_supportedEnyoBundleVersions.append(QString::fromStdString(version.asString()));
     }
 
-    appDesc->m_id = jsonObj["id"].toString().toStdString();
-    appDesc->m_entryPoint= jsonObj["main"].toString().toStdString();
-    appDesc->m_icon = jsonObj["icon"].toString().toStdString();
-    appDesc->m_folderPath = jsonObj["folderPath"].toString().toStdString();
-    appDesc->m_requestedWindowOrientation = jsonObj["requestedWindowOrientation"].toString().toStdString();
-    appDesc->m_title = jsonObj["title"].toString().toStdString();
-    appDesc->m_doNotTrack = jsonObj["doNotTrack"].toBool();
-    appDesc->m_handleExitKey = jsonObj["handleExitKey"].toBool();
-    appDesc->m_enableBackgroundRun = jsonObj["enableBackgroundRun"].toBool();
-    appDesc->m_allowVideoCapture = jsonObj["allowVideoCapture"].toBool();
-    appDesc->m_allowAudioCapture = jsonObj["allowAudioCapture"].toBool();
-    appDesc->m_usePrerendering = jsonObj.contains("usePrerendering") && jsonObj["usePrerendering"].toBool();
-    appDesc->m_disallowScrollingInMainFrame = !jsonObj.contains("disallowScrollingInMainFrame") || jsonObj["disallowScrollingInMainFrame"].toBool();
+    appDesc->m_id = jsonObj["id"].asString();
+    appDesc->m_entryPoint= jsonObj["main"].asString();
+    appDesc->m_icon = jsonObj["icon"].asString();
+    appDesc->m_folderPath = jsonObj["folderPath"].asString();
+    appDesc->m_requestedWindowOrientation = jsonObj["requestedWindowOrientation"].asString();
+    appDesc->m_title = jsonObj["title"].asString();
+    appDesc->m_doNotTrack = jsonObj["doNotTrack"].asBool();
+    appDesc->m_handleExitKey = jsonObj["handleExitKey"].asBool();
+    appDesc->m_enableBackgroundRun = jsonObj["enableBackgroundRun"].asBool();
+    appDesc->m_allowVideoCapture = jsonObj["allowVideoCapture"].asBool();
+    appDesc->m_allowAudioCapture = jsonObj["allowAudioCapture"].asBool();
+
+    auto usePrerendering = jsonObj["usePrerendering"];
+    appDesc->m_usePrerendering = usePrerendering.isBool() && usePrerendering.asBool();
+    auto disallowScrolling = jsonObj["disallowScrollingInMainFrame"];
+    appDesc->m_disallowScrollingInMainFrame = disallowScrolling.isBool() && disallowScrolling.asBool();
 
     // Handle accessibility, supportsAudioGuidance
-    if (!jsonObj.value("accessibility").isUndefined() && jsonObj.value("accessibility").isObject()) {
-        QJsonObject accessibilityObj = jsonObj["accessibility"].toObject();
-        if (!accessibilityObj.value("supportsAudioGuidance").isUndefined())
-            appDesc->m_supportsAudioGuidance = accessibilityObj["supportsAudioGuidance"].toBool();
+    auto accessibility = jsonObj["accessibility"];
+    if (accessibility.isObject()) {
+        auto audioGuidance = accessibility["supportsAudioGuidance"];
+        appDesc->m_supportsAudioGuidance = audioGuidance.isBool() && audioGuidance.asBool();
     }
 
     // Handle v8 snapshot file
-    if (!jsonObj.value("v8SnapshotFile").isUndefined()) {
-        std::string snapshotFile = jsonObj["v8SnapshotFile"].toString().toStdString();
+    auto v8SnapshotFile = jsonObj["v8SnapshotFile"];
+    if (v8SnapshotFile.isString()) {
+        std::string snapshotFile = v8SnapshotFile.asString();
         if (snapshotFile.length() > 0) {
             if (snapshotFile.at(0) == '/')
                 appDesc->m_v8SnapshotPath = snapshotFile;
@@ -196,12 +201,14 @@ ApplicationDescription* ApplicationDescription::fromJsonString(const char* jsonS
     }
 
     // Handle v8 extra flags
-    if (!jsonObj.value("v8ExtraFlags").isUndefined())
-        appDesc->m_v8ExtraFlags = jsonObj["v8ExtraFlags"].toString().toStdString();
+    auto v8ExtraFlags = jsonObj["v8ExtraFlags"];
+    if (v8ExtraFlags.isString())
+        appDesc->m_v8ExtraFlags = v8ExtraFlags.asString();
 
     // Handle resolution
-    if (!jsonObj.value("resolution").isUndefined()) {
-        QString overrideResolution = jsonObj["resolution"].toString();
+    auto resolution = jsonObj["resolution"];
+    if (resolution.isString()) {
+        QString overrideResolution = QString::fromStdString(jsonObj["resolution"].asString());
         QStringList resList(overrideResolution.split("x", QString::KeepEmptyParts, Qt::CaseInsensitive));
         if(resList.size() == 2) {
             appDesc->m_widthOverride = resList.at(0).toInt();
@@ -215,12 +222,15 @@ ApplicationDescription* ApplicationDescription::fromJsonString(const char* jsonS
 
     // Handle keyFilterTable
     //Key code is changed only for facebooklogin WebApp
-    if (!jsonObj.value("keyFilterTable").isUndefined()) {
-        QJsonArray keyFilterTable = jsonObj["keyFilterTable"].toArray();
-        for (int i=0 ; i < keyFilterTable.size() ; i++) {
-            QVariantMap map = keyFilterTable[i].toObject().toVariantMap();
-            if (!map.empty())
-                appDesc->m_keyFilterTable[map["from"].toString().toInt()] = qMakePair(map["to"].toString().toInt(), map["modifier"].toString().toInt());
+    auto keyFilterTable = jsonObj["keyFilterTable"];
+    if (keyFilterTable.isArray()) {
+        for (const auto &k : keyFilterTable) {
+            if (!k.isObject())
+                continue;
+            int from = std::stoi(k["from"].asString());
+            int to = std::stoi(k["to"].asString());
+            int mod = std::stoi(k["mod"].asString());
+            appDesc->m_keyFilterTable[from] = qMakePair(to, mod);
         }
     }
 
@@ -241,9 +251,9 @@ ApplicationDescription* ApplicationDescription::fromJsonString(const char* jsonS
     // class : { "hidden" : boolean }
     //
     WindowClass classValue = WindowClass_Normal;
-    if (!jsonObj.value("class").isUndefined() && jsonObj.value("class").isObject()) {
-        QJsonObject classObj = jsonObj["class"].toObject();
-        if (classObj["hidden"].toBool())
+    auto clazz = jsonObj["class"];
+    if (clazz.isObject()) {
+        if (clazz["hidden"].isBool() && clazz["hidden"].asBool())
             classValue = WindowClass_Hidden;
     }
     appDesc->m_windowClassValue = classValue;
@@ -261,16 +271,15 @@ ApplicationDescription* ApplicationDescription::fromJsonString(const char* jsonS
             appDesc->m_icon = tempPath;
         }
     }
-    appDesc->m_useNativeScroll = jsonObj.contains("useNativeScroll") && jsonObj["useNativeScroll"].toBool();
+    appDesc->m_useNativeScroll = jsonObj["useNativeScroll"].isBool() && jsonObj["useNativeScroll"].asBool();
 
     // Set network stable timeout
-    if(jsonObj.contains("networkStableTimeout")) {
-        if (jsonObj["networkStableTimeout"].type() != QJsonValue::Double)
-            LOG_ERROR(MSGID_TYPE_ERROR, 2, PMLOGKS("APP_ID", appDesc->id().c_str()),
-                PMLOGKFV("DATA_TYPE", "%d", jsonObj["networkStableTimeout"].type()),  "Invaild QJsonValue type");
-        else
-            appDesc->m_networkStableTimeout = jsonObj["networkStableTimeout"].toDouble();
-    }
+    auto networkStableTimeout = jsonObj["networkStableTimeout"];
+    if (!networkStableTimeout.isDouble())
+        LOG_ERROR(MSGID_TYPE_ERROR, 2, PMLOGKS("APP_ID", appDesc->id().c_str()),
+            PMLOGKFV("DATA_TYPE", "%d", networkStableTimeout.type()),  "Invaild JsonValue type");
+    else
+        appDesc->m_networkStableTimeout = networkStableTimeout.asDouble();
 
     return appDesc;
 }

--- a/src/core/ApplicationDescription.h
+++ b/src/core/ApplicationDescription.h
@@ -17,7 +17,6 @@
 #ifndef APPLICATIONDESCRIPTION_H
 #define APPLICATIONDESCRIPTION_H
 
-#include <QJsonObject>
 #include <QMap>
 #include <QPair>
 #include <QString>

--- a/src/core/WebAppBase.cpp
+++ b/src/core/WebAppBase.cpp
@@ -16,9 +16,7 @@
 
 #include "WebAppBase.h"
 
-#include <QtCore/QJsonDocument>
-#include <QtCore/QJsonObject>
-
+#include "JsonHelper.h"
 #include "ApplicationDescription.h"
 #include "LogManager.h"
 #include "WebAppManagerConfig.h"
@@ -378,24 +376,24 @@ void WebAppBase::setAppDescription(ApplicationDescription* appDesc)
 
 void WebAppBase::setAppProperties(QString properties)
 {
-    QJsonDocument doc = QJsonDocument::fromJson(properties.toStdString().c_str());
-    QJsonObject obj = doc.object();
+    Json::Value obj;
+    readJsonFromString(properties.toStdString(), obj);
 
-    if (obj["keepAlive"].toBool())
+    if (obj["keepAlive"].asBool())
         setKeepAlive(true);
     else
         setKeepAlive(false);
 
-    if (obj["launchedHidden"].toBool())
+    if (obj["launchedHidden"].asBool())
         setHiddenWindow(true);
 }
 
 void WebAppBase::setPreloadState(QString properties)
 {
-    QJsonDocument doc = QJsonDocument::fromJson(properties.toStdString().c_str());
-    QJsonObject obj = doc.object();
+    Json::Value obj;
+    readJsonFromString(properties.toStdString(), obj);
 
-    std::string preload = obj["preload"].toString().toStdString().c_str();
+    std::string preload = obj["preload"].asString();
 
     if (preload == "full") {
         m_preloadState = FULL_PRELOAD;
@@ -406,7 +404,7 @@ void WebAppBase::setPreloadState(QString properties)
     else if (preload == "minimal") {
         m_preloadState = MINIMAL_PRELOAD;
     }
-    else if (obj["launchedHidden"].toBool()) {
+    else if (obj["launchedHidden"].asBool()) {
         m_preloadState = PARTIAL_PRELOAD;
     }
 

--- a/src/core/WebAppBase.h
+++ b/src/core/WebAppBase.h
@@ -23,6 +23,10 @@
 #include "WebAppManager.h"
 #include "WebPageObserver.h"
 
+namespace Json {
+class Value;
+}
+
 class ApplicationDescription;
 class WebAppBasePrivate;
 class WebPageBase;
@@ -64,8 +68,8 @@ public:
     virtual void setWindowProperty(const QString& name, const QVariant& value) = 0;
     virtual void platformBack() = 0;
     virtual void setCursor(const QString& cursorArg, int hotspot_x, int hotspot_y) = 0;
-    virtual void setInputRegion(const QJsonDocument& jsonDoc) = 0;
-    virtual void setKeyMask(const QJsonDocument& jsonDoc) = 0;
+    virtual void setInputRegion(const Json::Value& jsonDoc) = 0;
+    virtual void setKeyMask(const Json::Value& jsonDoc) = 0;
     virtual void hide(bool forcedHide = false) = 0;
     virtual void focus() = 0;
     virtual void unfocus() = 0;

--- a/src/core/WebAppFactoryManager.cpp
+++ b/src/core/WebAppFactoryManager.cpp
@@ -17,9 +17,11 @@
 #include "WebAppFactoryManager.h"
 
 #include <QtCore/QDir>
+#include <QtCore/QPluginLoader>
+
+// FIXME: Remove once WebAppFactory pluggable system is dropped.
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
-#include <QtCore/QPluginLoader>
 
 #include "LogManager.h"
 #include "WebAppBase.h"
@@ -71,6 +73,8 @@ WebAppFactoryInterface* WebAppFactoryManager::loadPluggable(QString appType)
 
     WebAppFactoryInterface* interface;
     QDir pluginsDir(m_webAppFactoryPluginPath);
+
+    // FIXME: Remove once WebAppFactory pluggable system is dropped.
     Q_FOREACH (QString fileName, pluginsDir.entryList(QDir::Files)) {
         QPluginLoader pluginLoader(pluginsDir.absoluteFilePath(fileName));
         QString key = pluginLoader.metaData().value("MetaData").toObject().value("Keys").toArray().at(0).toString();

--- a/src/core/WebAppManager.cpp
+++ b/src/core/WebAppManager.cpp
@@ -20,11 +20,10 @@
 #include <sstream>
 #include <unistd.h>
 
-#include <QtCore/QJsonDocument>
-
 #include "ApplicationDescription.h"
 #include "ContainerAppManager.h"
 #include "DeviceInfo.h"
+#include "JsonHelper.h"
 #include "LogManager.h"
 #include "NetworkStatusManager.h"
 #include "PlatformModuleFactory.h"
@@ -266,12 +265,13 @@ void WebAppManager::onRelaunchApp(const std::string& instanceId, const std::stri
 
     // Do not relaunch when preload args is setted
     // luna-send -n 1 luna://com.webos.applicationManager/launch '{"id":<AppId> "preload":<PreloadState> }'
-    QJsonDocument doc = QJsonDocument::fromJson(args.c_str());
-    QJsonObject obj = doc.object();
+    Json::Value obj;
+    readJsonFromString(args, obj);
 
     if (app->instanceId() == QString::fromStdString(instanceId)
         && !obj["preload"].isString()
-        && !obj["launchedHidden"].toBool()) {
+        && obj["launchedHidden"].isBool()
+        && !obj["launchedHidden"].asBool()) {
         app->relaunch(args.c_str(), launchingAppId.c_str());
     } else {
         LOG_INFO(MSGID_WAM_DEBUG, 2, PMLOGKS("APP_ID", qPrintable(app->appId())), PMLOGKFV("PID", "%d", app->page()->getWebProcessPID()), "Relaunch with preload option, ignore");
@@ -875,7 +875,7 @@ std::vector<ApplicationInfo> WebAppManager::list( bool includeSystemApps )
     return list;
 }
 
-QJsonObject WebAppManager::getWebProcessProfiling()
+Json::Value WebAppManager::getWebProcessProfiling()
 {
     return m_webProcessManager->getWebProcessProfiling();
 }
@@ -1030,7 +1030,7 @@ void WebAppManager::serviceCall(const QString& url, const QString& payload, cons
         m_serviceSender->serviceCall(url, payload, appId);
 }
 
-void WebAppManager::updateNetworkStatus(const QJsonObject& object)
+void WebAppManager::updateNetworkStatus(const Json::Value& object)
 {
     NetworkStatus status;
     status.fromJsonObject(object);

--- a/src/core/WebAppManager.h
+++ b/src/core/WebAppManager.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <vector>
 
-#include <QJsonObject>
 #include <QMultiMap>
 #include <QString>
 
@@ -38,6 +37,10 @@ class WebProcessManager;
 class WebAppManagerConfig;
 class WebAppBase;
 class WebPageBase;
+
+namespace Json {
+class Value;
+};
 
 class ApplicationInfo {
 public:
@@ -87,7 +90,7 @@ public:
 
     std::vector<ApplicationInfo> list(bool includeSystemApps = false);
 
-    QJsonObject getWebProcessProfiling();
+    Json::Value getWebProcessProfiling();
 #ifndef PRELOADMANAGER_ENABLED
     void sendLaunchContainerApp();
     void startContainerTimer();
@@ -151,7 +154,7 @@ public:
     uint32_t getWebProcessId(const QString& appId);
     void sendEventToAllAppsAndAllFrames(const QString& jsscript);
     void serviceCall(const QString& url, const QString& payload, const QString& appId);
-    void updateNetworkStatus(const QJsonObject& object);
+    void updateNetworkStatus(const Json::Value& object);
     void notifyMemoryPressure(webos::WebViewBase::MemoryPressureLevel level);
 
     bool isEnyoApp(const QString& appId);

--- a/src/core/WebAppManagerService.cpp
+++ b/src/core/WebAppManagerService.cpp
@@ -38,17 +38,17 @@ bool WebAppManagerService::onKillApp(const std::string& appId)
     return WebAppManager::instance()->onKillApp(appId);
 }
 
-QJsonObject WebAppManagerService::onLogControl(const std::string& keys, const std::string& value)
+Json::Value WebAppManagerService::onLogControl(const std::string& keys, const std::string& value)
 {
     LogManager::setLogControl(keys, value);
 
-    QJsonObject reply;
+    Json::Value reply(Json::objectValue);
 
     reply["event"] = LogManager::getDebugEventsEnabled();
     reply["bundleMessage"] = LogManager::getDebugBundleMessagesEnabled();
     reply["mouseMove"] = LogManager::getDebugMouseMoveEnabled();
 
-    return reply;
+    return std::move(reply);
 }
 
 bool WebAppManagerService::onCloseAllApps(uint32_t pid)
@@ -172,7 +172,7 @@ std::vector<ApplicationInfo> WebAppManagerService::list(bool includeSystemApps)
     return WebAppManager::instance()->list(includeSystemApps);
 }
 
-QJsonObject WebAppManagerService::closeByInstanceId(QString instanceId)
+Json::Value WebAppManagerService::closeByInstanceId(QString instanceId)
 {
     LOG_INFO(MSGID_LUNA_API, 2, PMLOGKS("INSTANCE_ID", qPrintable(instanceId)), PMLOGKS("API", "closeByInstanceId"), "");
     WebAppBase* app = WebAppManager::instance()->findAppByInstanceId(instanceId);
@@ -182,15 +182,15 @@ QJsonObject WebAppManagerService::closeByInstanceId(QString instanceId)
         WebAppManager::instance()->forceCloseAppInternal(app);
     }
 
-    QJsonObject reply;
+    Json::Value reply(Json::objectValue);
     if(!appId.isNull()) {
-        reply["appId"] = appId;
-        reply["processId"] = instanceId;
+        reply["appId"] = appId.toStdString();
+        reply["processId"] = instanceId.toStdString();
         reply["returnValue"] = true;
     }
     else {
         LOG_INFO(MSGID_LUNA_API, 2, PMLOGKS("INSTANCE_ID", qPrintable(instanceId)), PMLOGKS("API", "closeByInstanceId"), "No matched App; return false");
-        QString errMsg("Unknown Process");
+        std::string errMsg("Unknown Process");
         reply["returnValue"] = false;
         reply["errorText"] = errMsg;
     }

--- a/src/core/WebAppManagerService.cpp
+++ b/src/core/WebAppManagerService.cpp
@@ -16,6 +16,7 @@
 
 #include "WebAppManagerService.h"
 
+#include <json/value.h>
 #include <vector>
 
 #include "LogManager.h"
@@ -77,7 +78,7 @@ bool WebAppManagerService::onPurgeSurfacePool(uint32_t pid)
     return WebAppManager::instance()->purgeSurfacePool(pid);
 }
 
-QJsonObject WebAppManagerService::getWebProcessProfiling()
+Json::Value WebAppManagerService::getWebProcessProfiling()
 {
     return WebAppManager::instance()->getWebProcessProfiling();
 }
@@ -206,7 +207,7 @@ uint32_t WebAppManagerService::getWebProcessId(const QString& appId)
     return WebAppManager::instance()->getWebProcessId(appId);
 }
 
-void WebAppManagerService::updateNetworkStatus(const QJsonObject& object)
+void WebAppManagerService::updateNetworkStatus(const Json::Value& object)
 {
     WebAppManager::instance()->updateNetworkStatus(object);
 }

--- a/src/core/WebAppManagerService.h
+++ b/src/core/WebAppManagerService.h
@@ -17,11 +17,16 @@
 #ifndef WEBAPPMANAGERSERVICE_H
 #define WEBAPPMANAGERSERVICE_H
 
+//FIXME: Remove once QJson* is fully dropped from WebAppManagerService
 #include <QJsonObject>
 
 #include "WebAppManager.h"
 
 #include "webos/webview_base.h"
+
+namespace Json {
+class Value;
+}
 
 enum ErrorCode {
     ERR_CODE_LAUNCHAPP_MISS_PARAM = 1000,
@@ -78,7 +83,7 @@ protected:
     bool isDiscardCodeCacheRequired();
     void onDiscardCodeCache(uint32_t pid);
     bool onPurgeSurfacePool(uint32_t pid);
-    QJsonObject getWebProcessProfiling();
+    Json::Value getWebProcessProfiling();
     QJsonObject closeByInstanceId(QString instanceId);
     int maskForBrowsingDataType(const char* type);
     void onClearBrowsingData(const int removeBrowsingDataMask);
@@ -99,7 +104,7 @@ protected:
     void killCustomPluginProcess(const QString& appBasePath);
     void requestKillWebProcess(uint32_t pid);
     bool shouldLaunchContainerAppOnDemand();
-    void updateNetworkStatus(const QJsonObject& object);
+    void updateNetworkStatus(const Json::Value& object);
     void notifyMemoryPressure(webos::WebViewBase::MemoryPressureLevel level);
     void setAccessibilityEnabled(bool enable);
     uint32_t getWebProcessId(const QString& appId);

--- a/src/core/WebAppManagerService.h
+++ b/src/core/WebAppManagerService.h
@@ -17,9 +17,6 @@
 #ifndef WEBAPPMANAGERSERVICE_H
 #define WEBAPPMANAGERSERVICE_H
 
-//FIXME: Remove once QJson* is fully dropped from WebAppManagerService
-#include <QJsonObject>
-
 #include "WebAppManager.h"
 
 #include "webos/webview_base.h"
@@ -57,17 +54,17 @@ public:
 
     virtual bool startService() = 0;
     // methods published to the bus
-    virtual QJsonObject launchApp(QJsonObject request) = 0;
-    virtual QJsonObject killApp(QJsonObject request) = 0;
-    virtual QJsonObject logControl(QJsonObject request) = 0;
-    virtual QJsonObject setInspectorEnable(QJsonObject request) = 0;
-    virtual QJsonObject closeAllApps(QJsonObject request) = 0;
-    virtual QJsonObject discardCodeCache(QJsonObject request) = 0;
-    virtual QJsonObject listRunningApps(QJsonObject request, bool subscribed) = 0;
-    virtual QJsonObject closeByProcessId(QJsonObject request) = 0;
-    virtual QJsonObject getWebProcessSize(QJsonObject request) = 0;
-    virtual QJsonObject clearBrowsingData(QJsonObject request) = 0;
-    virtual QJsonObject webProcessCreated(QJsonObject request, bool subscribed) = 0;
+    virtual Json::Value launchApp(const Json::Value &request) = 0;
+    virtual Json::Value killApp(const Json::Value &request) = 0;
+    virtual Json::Value logControl(const Json::Value &request) = 0;
+    virtual Json::Value setInspectorEnable(const Json::Value &request) = 0;
+    virtual Json::Value closeAllApps(const Json::Value &request) = 0;
+    virtual Json::Value discardCodeCache(const Json::Value &request) = 0;
+    virtual Json::Value listRunningApps(const Json::Value &request, bool subscribed) = 0;
+    virtual Json::Value closeByProcessId(const Json::Value &request) = 0;
+    virtual Json::Value getWebProcessSize(const Json::Value &request) = 0;
+    virtual Json::Value clearBrowsingData(const Json::Value &request) = 0;
+    virtual Json::Value webProcessCreated(const Json::Value &request, bool subscribed) = 0;
 
 protected:
     std::string onLaunch(const std::string& appDescString,
@@ -77,14 +74,14 @@ protected:
         std::string& errMsg);
 
     bool onKillApp(const std::string& appId);
-    QJsonObject onLogControl(const std::string& keys, const std::string& value);
+    Json::Value onLogControl(const std::string& keys, const std::string& value);
     bool onCloseAllApps(uint32_t pid = 0);
     bool closeContainerApp();
     bool isDiscardCodeCacheRequired();
     void onDiscardCodeCache(uint32_t pid);
     bool onPurgeSurfacePool(uint32_t pid);
     Json::Value getWebProcessProfiling();
-    QJsonObject closeByInstanceId(QString instanceId);
+    Json::Value closeByInstanceId(QString instanceId);
     int maskForBrowsingDataType(const char* type);
     void onClearBrowsingData(const int removeBrowsingDataMask);
     void setProxyRules(const std::string& proxy_rules);

--- a/src/core/WebPageBase.cpp
+++ b/src/core/WebPageBase.cpp
@@ -18,10 +18,9 @@
 
 #include <QDir>
 #include <QFileInfo>
-#include <QtCore/QJsonDocument>
-#include <QtCore/QJsonObject>
 
 #include "ApplicationDescription.h"
+#include "JsonHelper.h"
 #include "LogManager.h"
 #include "WebAppManagerConfig.h"
 #include "WebAppManager.h"
@@ -179,11 +178,12 @@ bool WebPageBase::doHostedWebAppRelaunch(const QString& launchParams)
     To support backward compatibility, should cover the case not having "handledBy"
     */
     // check deeplinking relaunch condition
-    QJsonObject obj = QJsonDocument::fromJson(launchParams.toUtf8()).object();
+    Json::Value obj;
+    readJsonFromString(launchParams.toStdString(), obj);
     if (url().scheme() ==  "file"
         || m_defaultUrl.scheme() != "file"
-        || obj.isEmpty() /* no launchParams, { }, and this should be check with object().isEmpty()*/
-        || obj.value("contentTarget").isUndefined()
+        || !obj.isObject() /* no launchParams, { }, and this should be check with object().isEmpty()*/
+        || obj["contentTarget"].isNull()
         || (m_appDesc && !m_appDesc->handlesDeeplinking())) {
         LOG_INFO(MSGID_WEBPAGE_RELAUNCH, 2, PMLOGKS("APP_ID", qPrintable(appId())), PMLOGKFV("PID", "%d", getWebProcessPID()),
             "%s; NOT enough deeplinking condition; return false", __func__);
@@ -195,15 +195,17 @@ bool WebPageBase::doHostedWebAppRelaunch(const QString& launchParams)
     return doDeeplinking(launchParams);
 }
 
+// TODO: Optimization: Consider use previously parsed Json::Object here instead of std::string
 bool WebPageBase::doDeeplinking(const QString& launchParams)
 {
-    QJsonObject obj = QJsonDocument::fromJson(launchParams.toUtf8()).object();
-    if (obj.isEmpty() || obj.value("contentTarget").isUndefined())
+    Json::Value obj;
+    readJsonFromString(launchParams.toStdString(), obj);
+    if (!obj.isObject() || obj["contentTarget"].isNull())
         return false;
 
-    std::string handledBy = obj.value("handledBy").isUndefined() ? "default" : obj.value("handledBy").toString().toStdString();
+    std::string handledBy = obj["handledBy"].isNull() ? "default" : obj["handledBy"].asString();
     if (handledBy == "platform") {
-        std::string targetUrl = obj.value("contentTarget").toString().toStdString();
+        std::string targetUrl = obj["contentTarget"].asString();
         LOG_INFO(MSGID_DEEPLINKING, 3, PMLOGKS("APP_ID", qPrintable(appId())), PMLOGKFV("PID", "%d", getWebProcessPID()),
             PMLOGKS("handledBy", handledBy.c_str()),
             "%s; load target URL:%s", __func__, targetUrl.c_str());

--- a/src/core/WebProcessManager.h
+++ b/src/core/WebProcessManager.h
@@ -19,7 +19,6 @@
 
 #include <list>
 
-#include <QJsonObject>
 #include <QList>
 #include <QMap>
 #include <QString>
@@ -27,6 +26,10 @@
 class ApplicationDescription;
 class WebPageBase;
 class WebAppBase;
+
+namespace Json {
+class Value;
+}
 
 class WebProcessManager {
 public:
@@ -39,11 +42,11 @@ public:
     void killWebProcess(uint32_t pid);
     void requestKillWebProcess(uint32_t pid);
     bool webProcessInfoMapReady();
-    void setWebProcessCacheProperty(QJsonObject object, QString key); //change name from setWebProcessProperty()
+    void setWebProcessCacheProperty(const Json::Value &object, QString key); //change name from setWebProcessProperty()
     void readWebProcessPolicy(); //chane name from setWebProcessEnvironment()
     QString getProcessKey(const ApplicationDescription* desc) const; //change name from getKey()
 
-    virtual QJsonObject getWebProcessProfiling() = 0;
+    virtual Json::Value getWebProcessProfiling() = 0;
     virtual uint32_t getWebProcessPID(const WebAppBase* app) const = 0;
     virtual void deleteStorageData(const QString& identifier) = 0;
     virtual uint32_t getInitialWebViewProxyID() const = 0;

--- a/src/platform/PalmSystemWebOS.h
+++ b/src/platform/PalmSystemWebOS.h
@@ -23,6 +23,10 @@
 #include <PmLogLib.h>
 #endif
 
+namespace Json {
+class Value;
+};
+
 class WebAppBase;
 class WebAppWayland;
 
@@ -43,7 +47,7 @@ protected:
         FocusLayer
     };
 
-    virtual QJsonDocument initialize();
+    virtual Json::Value initialize();
 
     virtual QString identifier() const = 0;
     virtual QString launchParams() const { return m_launchParams; }

--- a/src/platform/WebAppWayland.cpp
+++ b/src/platform/WebAppWayland.cpp
@@ -16,8 +16,7 @@
 
 #include "WebAppWayland.h"
 
-#include <QtCore/QJsonDocument>
-#include <QtCore/QJsonArray>
+#include <json/json.h>
 
 #include "ApplicationDescription.h"
 #include "LogManager.h"
@@ -304,20 +303,17 @@ void WebAppWayland::applyInputRegion()
 #endif
 }
 
-void WebAppWayland::setInputRegion(const QJsonDocument& jsonDoc)
+void WebAppWayland::setInputRegion(const Json::Value& jsonDoc)
 {
     m_inputRegion.clear();
 
     if (jsonDoc.isArray()) {
-        QJsonArray jsonArray = jsonDoc.array();
-
-        for (int i = 0; i < jsonArray.size(); i++) {
-            QVariantMap map = jsonArray[i].toObject().toVariantMap();
+        for (const Json::Value& map : jsonDoc) {
             m_inputRegion.push_back(gfx::Rect(
-                                map["x"].toInt() * m_scaleFactor,
-                                map["y"].toInt() * m_scaleFactor,
-                                map["width"].toInt() * m_scaleFactor,
-                                map["height"].toInt() * m_scaleFactor));
+                                map["x"].asInt() * m_scaleFactor,
+                                map["y"].asInt() * m_scaleFactor,
+                                map["width"].asInt() * m_scaleFactor,
+                                map["height"].asInt() * m_scaleFactor));
         }
     }
 #if defined(OS_WEBOS)
@@ -377,16 +373,14 @@ static QMap<QString, webos::WebOSKeyMask>& getKeyMaskTable()
     return mapTable;
 }
 
-void WebAppWayland::setKeyMask(const QJsonDocument& jsonDoc)
+void WebAppWayland::setKeyMask(const Json::Value& jsonDoc)
 {
     static QMap<QString, webos::WebOSKeyMask>& mapTable = getKeyMaskTable();
     unsigned int keyMask = 0;
 
     if (jsonDoc.isArray()) {
-        QJsonArray jsonArray = jsonDoc.array();
-
-        for (int i = 0; i < jsonArray.size(); i++)
-            keyMask |= mapTable.value(jsonArray[i].toString());
+        for (const Json::Value& child : jsonDoc)
+            keyMask |= mapTable.value(QString::fromStdString(child.asString()));
     }
 #if defined(OS_WEBOS)
     webos::WebOSPlatform::GetInstance()->SetKeyMask(m_windowHandle, static_cast<webos::WebOSKeyMask>(keyMask));

--- a/src/platform/WebAppWayland.h
+++ b/src/platform/WebAppWayland.h
@@ -26,6 +26,10 @@
 #include "webos/common/webos_event.h"
 #include "webos/webos_platform.h"
 
+namespace Json {
+class Value;
+}
+
 class ApplicationDescription;
 class WebAppWaylandWindow;
 
@@ -72,8 +76,8 @@ public:
     void setWindowProperty(const QString& name, const QVariant& value) override;
     void platformBack() override;
     void setCursor(const QString& cursorArg, int hotspot_x = -1, int hotspot_y = -1) override;
-    void setInputRegion(const QJsonDocument& jsonDoc) override;
-    void setKeyMask(const QJsonDocument& jsonDoc) override;
+    void setInputRegion(const Json::Value& jsonDoc) override;
+    void setKeyMask(const Json::Value& jsonDoc) override;
     void setOpacity(float opacity) override;
     void hide(bool forcedHide = false) override;
     void focus() override;

--- a/src/platform/webengine/BlinkWebProcessManager.h
+++ b/src/platform/webengine/BlinkWebProcessManager.h
@@ -22,10 +22,14 @@
 class QString;
 class WebAppBase;
 
+namespace Json {
+class Value;
+}
+
 class BlinkWebProcessManager : public WebProcessManager {
 public:
     // WebProcessManager
-    QJsonObject getWebProcessProfiling() override;
+    Json::Value getWebProcessProfiling() override;
     uint32_t getWebProcessPID(const WebAppBase* app) const override;
     void deleteStorageData(const QString& identifier) override;
     uint32_t getInitialWebViewProxyID() const override;

--- a/src/platform/webengine/PalmSystemBlink.cpp
+++ b/src/platform/webengine/PalmSystemBlink.cpp
@@ -14,14 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "JsonHelper.h"
 #include "LogManager.h"
 #include "PalmSystemBlink.h"
 #include "WebAppBase.h"
 #include "WebAppWayland.h"
 #include "WebPageBlink.h"
 
-#include <QtCore/QJsonObject>
-#include <QtCore/QJsonDocument>
 #include <QtCore/QDataStream>
 
 PalmSystemBlink::PalmSystemBlink(WebAppBase* app)
@@ -32,7 +31,9 @@ PalmSystemBlink::PalmSystemBlink(WebAppBase* app)
 QString PalmSystemBlink::handleBrowserControlMessage(const QString& message, const QStringList& params)
 {
     if (message == "initialize") {
-        return initialize().toJson();
+        std::string json;
+        dumpJsonToString(initialize(), json);
+        return QString::fromStdString(json);
     } else if (message == "country") {
         return country();
     } else if (message == "locale") {
@@ -202,13 +203,12 @@ double PalmSystemBlink::devicePixelRatio()
     return static_cast<WebPageBlink*>(m_app->page())->devicePixelRatio();
 }
 
-QJsonDocument PalmSystemBlink::initialize()
+Json::Value PalmSystemBlink::initialize()
 {
-    QJsonObject data = PalmSystemWebOS::initialize().object();
+    Json::Value data = PalmSystemWebOS::initialize();
     data["devicePixelRatio"] = devicePixelRatio();
-    data["trustLevel"] = trustLevel();
-    QJsonDocument doc(data);
-    return doc;
+    data["trustLevel"] = trustLevel().toStdString();
+    return std::move(data);
 }
 
 

--- a/src/platform/webengine/PalmSystemBlink.h
+++ b/src/platform/webengine/PalmSystemBlink.h
@@ -19,6 +19,10 @@
 
 #include "PalmSystemWebOS.h"
 
+namespace Json {
+class Value;
+}
+
 class PalmSystemBlink : public PalmSystemWebOS {
 public:
     PalmSystemBlink(WebAppBase* app);
@@ -34,7 +38,7 @@ public:
 
 protected:
     // PalmSystemWebOS
-    QJsonDocument initialize() override;
+    Json::Value initialize() override;
     QString identifier() const override;
     void setLoadErrorPolicy(const QString& params) override;
 

--- a/src/util/JsonHelper.cpp
+++ b/src/util/JsonHelper.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2008-2018 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "JsonHelper.h"
+
+#include <memory>
+#include <fstream>
+#include <sstream>
+
+#include <json/reader.h>
+#include <json/writer.h>
+
+#include "LogManager.h"
+
+// TODO: Log error/warn messages when something wrong happens(?)
+bool readJsonFromString(const std::string &in, Json::Value& out) {
+    Json::Value jsonObj;
+    try {
+        std::istringstream(in) >> jsonObj;
+    } catch (const Json::RuntimeError &) {
+        return false;
+    }
+    out = jsonObj;
+    return true;
+}
+
+bool readJsonFromFile(const std::string &path, Json::Value& out) {
+    std::ifstream in(path);
+    if (!in.is_open()) {
+        return false;
+    }
+    Json::Value jsonObj;
+    try {
+        in >> jsonObj;
+    } catch (const Json::RuntimeError &) {
+        return false;
+    }
+    out = jsonObj;
+    return true;
+}
+
+// FIXME: Using default writter settings for now (e.g: indentation
+// enable, etc).
+bool dumpJsonToString(const Json::Value &json, std::string &out) {
+    std::stringstream ss;
+    try {
+        ss << json;
+    } catch (const Json::RuntimeError &) {
+        return false;
+    }
+    out = ss.str();
+    return true;
+}
+

--- a/src/util/JsonHelper.h
+++ b/src/util/JsonHelper.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2008-2018 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef JSONHELPER_H
+#define JSONHELPER_H
+
+#include <json/value.h>
+#include <string>
+
+bool readJsonFromString(const std::string &in, Json::Value& out);
+
+bool readJsonFromFile(const std::string &path, Json::Value& out);
+
+bool dumpJsonToString(const Json::Value &json, std::string &out);
+
+#endif // JSONHELPER_H

--- a/src/util/NetworkStatus.cpp
+++ b/src/util/NetworkStatus.cpp
@@ -14,8 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <time.h>
 #include "NetworkStatus.h"
+
+#include <json/json.h>
+#include <time.h>
+
 
 NetworkStatus::NetworkStatus()
     : m_isInternetConnectionAvailable(false)
@@ -23,20 +26,20 @@ NetworkStatus::NetworkStatus()
 {
 }
 
-void NetworkStatus::fromJsonObject(const QJsonObject& object)
+void NetworkStatus::fromJsonObject(const Json::Value& object)
 {
-    m_returnValue = object["returnValue"].toBool();
-    m_isInternetConnectionAvailable = object["isInternetConnectionAvailable"].toBool();
+    m_returnValue = object["returnValue"].asBool();
+    m_isInternetConnectionAvailable = object["isInternetConnectionAvailable"].asBool();
     if (m_returnValue) {
-        if (!object["wired"].isUndefined()) {
+        if (object["wired"].isObject()) {
             m_type = "wired";
-            m_information.fromJsonObject(object["wired"].toObject());
-        } else if (!object["wifi"].isUndefined()) {
+            m_information.fromJsonObject(object["wired"]);
+        } else if (object["wifi"].isObject()) {
             m_type = "wifi";
-            m_information.fromJsonObject(object["wifi"].toObject());
-        } else {
+            m_information.fromJsonObject(object["wifi"]);
+        } else if (object["wifiDirect"].isObject()) {
             m_type = "wifiDirect";
-            m_information.fromJsonObject(object["wifiDirect"].toObject());
+            m_information.fromJsonObject(object["wifiDirect"]);
         }
     }
 
@@ -46,16 +49,16 @@ void NetworkStatus::fromJsonObject(const QJsonObject& object)
     m_savedDate = m_savedDate.trimmed();
 }
 
-void NetworkStatus::Information::fromJsonObject(const QJsonObject& info)
+void NetworkStatus::Information::fromJsonObject(const Json::Value& info)
 {
-    m_netmask = info["netmask"].toString();
-    m_dns1 = info["dns1"].toString();
-    if (!info["dns2"].isUndefined())
-        m_dns2 = info["dns2"].toString();
-    m_ipAddress = info["ipAddress"].toString();
-    m_method = info["method"].toString();
-    m_state = info["state"].toString();
-    m_gateway = info["gateway"].toString();
-    m_interfaceName = info["interfaceName"].toString();
-    m_onInternet = info["onInternet"].toString();
+    m_netmask = QString::fromStdString(info["netmask"].asString());
+    m_dns1 = QString::fromStdString(info["dns1"].asString());
+    if (info["dns2"].isString())
+        m_dns2 = QString::fromStdString(info["dns2"].asString());
+    m_ipAddress = QString::fromStdString(info["ipAddress"].asString());
+    m_method = QString::fromStdString(info["method"].asString());
+    m_state = QString::fromStdString(info["state"].asString());
+    m_gateway = QString::fromStdString(info["gateway"].asString());
+    m_interfaceName = QString::fromStdString(info["interfaceName"].asString());
+    m_onInternet = QString::fromStdString(info["onInternet"].asString());
 }

--- a/src/util/NetworkStatus.h
+++ b/src/util/NetworkStatus.h
@@ -17,8 +17,11 @@
 #ifndef NETWORKSTATUS_H
 #define NETWORKSTATUS_H
 
-#include <QJsonObject>
 #include <QString>
+
+namespace Json {
+class Value;
+};
 
 class NetworkStatus {
 public:
@@ -26,7 +29,7 @@ public:
 
     class Information {
     public:
-        void fromJsonObject(const QJsonObject&);
+        void fromJsonObject(const Json::Value&);
         QString netmask() const { return m_netmask; }
         QString dns1() const { return m_dns1; }
         QString dns2() const { return m_dns2; }
@@ -49,7 +52,7 @@ public:
         QString m_onInternet;
     };
 
-    void fromJsonObject(const QJsonObject&);
+    void fromJsonObject(const Json::Value&);
     QString type() const { return m_type; }
     Information information() const { return m_information; }
     QString savedDate() const { return m_savedDate; }

--- a/wamcorelib.pri
+++ b/wamcorelib.pri
@@ -22,6 +22,7 @@ SOURCES += \
         ApplicationDescription.cpp \
         ContainerAppManager.cpp \
         DeviceInfo.cpp \
+        JsonHelper.cpp \
         LogManager.cpp \
         NetworkStatus.cpp \
         NetworkStatusManager.cpp \
@@ -42,6 +43,7 @@ HEADERS += \
         ApplicationDescription.h \
         ContainerAppManager.h \
         DeviceInfo.h \
+        JsonHelper.h \
         LogManager.h \
         LogMsgId.h \
         NetworkStatus.h \


### PR DESCRIPTION
This PR refactors WAM JSON handling code to use Jsoncpp library instead of Qt's QJson* APIs. This is part of Qt-less WAM effort, which aims to remove the WAM dependency on Qt framework.

- PS 1: These patches modifies only classes involved in AGL build of WAM. It doesn't touch `src/webos` classes, for example. Those classes might be addressed in separate patches.
- PS 2: The only references to QJson APIs remaining after these patches are in `src/core/WebAppFactoryManager.cpp`, which is part of WAM Plugin-based WebAppFactory implementation, which will be addressed in upcoming PRs, see [SPEC-1913](https://jira.automotivelinux.org/browse/SPEC-1913) for details. To check QJson mentioned leftovers, one may run the following bash command in WAM root dir:
```sh
$ grep QJson $(find -name '*.cpp' -or -name '*.h'| grep -v ^./src/webos)
```

More details:
- [[SPEC-1910] Qt-less WAM: replace QJson classes usage in WAM](https://jira.automotivelinux.org/browse/SPEC-1910)
- [[SPEC-1907] Qt-less WAM: do not use Qt JSON](https://jira.automotivelinux.org/browse/SPEC-1907)
- [[SPEC-1871] [meta] Qt-less WAM](https://jira.automotivelinux.org/browse/SPEC-1871)
