### PR TITLE
Store proxy rules in WebView profiles

### DIFF
--- a/src/agl/WebAppManagerServiceAGL.cpp
+++ b/src/agl/WebAppManagerServiceAGL.cpp
@@ -340,7 +340,7 @@ fprintf(stderr, "    url: %s\r\n", startup_app_uri_.c_str());
     std::string errMsg;
 
     if (!startup_proxy_rules_.empty())
-        WebAppManagerService::setProxyRules(startup_proxy_rules_);
+        WebAppManagerService::buildWebViewProfile(app_id, startup_proxy_rules_);
 
     WebAppManagerService::onLaunch(appDesc, params, app_id, errCode, errMsg);
 }

--- a/src/core/WebAppManager.cpp
+++ b/src/core/WebAppManager.cpp
@@ -1058,8 +1058,8 @@ int WebAppManager::maskForBrowsingDataType(const char* type)
     return m_webProcessManager->maskForBrowsingDataType(type);
 }
 
-void WebAppManager::setProxyRules(const std::string& proxy_rules)
+void WebAppManager::buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules)
 {
     if (m_webProcessManager)
-        m_webProcessManager->setProxyRules(proxy_rules);
+        m_webProcessManager->buildWebViewProfile(app_id, proxy_rules);
 }

--- a/src/core/WebAppManager.h
+++ b/src/core/WebAppManager.h
@@ -160,7 +160,7 @@ public:
 
     void clearBrowsingData(const int removeBrowsingDataMask);
     int maskForBrowsingDataType(const char* type);
-    void setProxyRules(const std::string& proxy_rules);
+    void buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules);
 
 protected:
 private:

--- a/src/core/WebAppManagerService.cpp
+++ b/src/core/WebAppManagerService.cpp
@@ -226,7 +226,7 @@ int WebAppManagerService::maskForBrowsingDataType(const char* type)
     return WebAppManager::instance()->maskForBrowsingDataType(type);
 }
 
-void WebAppManagerService::setProxyRules(const std::string& proxy_rules)
+void WebAppManagerService::buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules)
 {
-    WebAppManager::instance()->setProxyRules(proxy_rules);
+    WebAppManager::instance()->buildWebViewProfile(app_id, proxy_rules);
 }

--- a/src/core/WebAppManagerService.h
+++ b/src/core/WebAppManagerService.h
@@ -82,7 +82,7 @@ protected:
     QJsonObject closeByInstanceId(QString instanceId);
     int maskForBrowsingDataType(const char* type);
     void onClearBrowsingData(const int removeBrowsingDataMask);
-    void setProxyRules(const std::string& proxy_rules);
+    void buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules);
 
     WebAppBase* getContainerApp();
 #ifndef PRELOADMANAGER_ENABLED

--- a/src/core/WebProcessManager.h
+++ b/src/core/WebProcessManager.h
@@ -49,7 +49,8 @@ public:
     virtual uint32_t getInitialWebViewProxyID() const = 0;
     virtual void clearBrowsingData(const int removeBrowsingDataMask) = 0;
     virtual int maskForBrowsingDataType(const char* type) = 0;
-    virtual void setProxyRules(const std::string& proxy_rules) = 0;
+    virtual void buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules) = 0;
+
 protected:
     std::list<const WebAppBase*> runningApps();
     std::list<const WebAppBase*> runningApps(uint32_t pid);

--- a/src/platform/webengine/BlinkWebProcessManager.cpp
+++ b/src/platform/webengine/BlinkWebProcessManager.cpp
@@ -120,6 +120,7 @@ int BlinkWebProcessManager::maskForBrowsingDataType(const char* type)
     return BlinkWebViewProfileHelper::maskForBrowsingDataType(type);
 }
 
-void BlinkWebProcessManager::setProxyRules(const std::string& proxy_rules) {
-    BlinkWebViewProfileHelper::setProxyRules(proxy_rules);
+void BlinkWebProcessManager::buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules)
+{
+    BlinkWebViewProfileHelper::instance()->buildProfile(app_id, proxy_rules);
 }

--- a/src/platform/webengine/BlinkWebProcessManager.h
+++ b/src/platform/webengine/BlinkWebProcessManager.h
@@ -31,7 +31,7 @@ public:
     uint32_t getInitialWebViewProxyID() const override;
     void clearBrowsingData(const int removeBrowsingDataMask) override;
     int maskForBrowsingDataType(const char* type) override;
-    void setProxyRules(const std::string& proxy_rules) override;
+    void buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules) override;
 };
 
 #endif /* BLINKEBPROCESSMANAGER_H */

--- a/src/platform/webengine/BlinkWebViewProfileHelper.cpp
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.cpp
@@ -16,9 +16,16 @@
 
 
 #include "BlinkWebViewProfileHelper.h"
+
 #include "webos/webview_profile.h"
 
+#include <cassert>
 #include <cstring>
+
+BlinkWebViewProfileHelper* BlinkWebViewProfileHelper::instance() {
+    static BlinkWebViewProfileHelper* sInstance = new BlinkWebViewProfileHelper();
+    return sInstance;
+}
 
 void BlinkWebViewProfileHelper::clearBrowsingData(const int removeBrowsingDataMask,
         webos::WebViewProfile *profile)
@@ -66,6 +73,16 @@ int BlinkWebViewProfileHelper::maskForBrowsingDataType(const char* type) {
     return 0;
 }
 
-void BlinkWebViewProfileHelper::setProxyRules(const std::string& proxy_rules) {
-    webos::WebViewProfile::GetDefaultProfile()->SetProxyRules(proxy_rules);
+webos::WebViewProfile* BlinkWebViewProfileHelper::getProfile(const std::string& app_id) {
+    if (m_appProfileMap.find(app_id) == m_appProfileMap.end())
+       return nullptr;
+    return m_appProfileMap[app_id];
+}
+
+void BlinkWebViewProfileHelper::buildProfile(const std::string& app_id, const std::string& proxy_rules)
+{
+    assert(m_appProfileMap.count(app_id) == 0);
+    webos::WebViewProfile* profile = new webos::WebViewProfile(app_id);
+    profile->SetProxyRules(proxy_rules);
+    m_appProfileMap[app_id] = profile;
 }

--- a/src/platform/webengine/BlinkWebViewProfileHelper.h
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.h
@@ -17,6 +17,7 @@
 #ifndef BLINK_WEB_VIEW_PROFILE_HELPER_H_
 #define BLINK_WEB_VIEW_PROFILE_HELPER_H_
 
+#include <map>
 #include <string>
 
 namespace webos {
@@ -40,14 +41,20 @@ const char kWebSQL[] = "webSQL";
 
 class BlinkWebViewProfileHelper {
 public:
-    BlinkWebViewProfileHelper() {}
-    virtual ~BlinkWebViewProfileHelper() {}
+    static BlinkWebViewProfileHelper* instance();
 
     static void clearBrowsingData(const int removeBrowsingDataMask,
         webos::WebViewProfile* profile = nullptr);
     static void clearDefaultBrowsingData(const int removeBrowsingDataMask);
     static int maskForBrowsingDataType(const char* key);
-    static void setProxyRules(const std::string& proxy_rules);
+    webos::WebViewProfile* getProfile(const std::string& app_id);
+    void buildProfile(const std::string& app_id, const std::string& proxy_rules);
+
+private:
+    BlinkWebViewProfileHelper() {}
+    virtual ~BlinkWebViewProfileHelper() = default;
+
+    std::map<const std::string, webos::WebViewProfile*> m_appProfileMap;
 };
 
 #endif // BLINK_WEB_VIEW_PROFILE_HELPER_H_

--- a/src/platform/webengine/WebPageBlink.cpp
+++ b/src/platform/webengine/WebPageBlink.cpp
@@ -27,6 +27,7 @@
 #include "ApplicationDescription.h"
 #include "BlinkWebProcessManager.h"
 #include "BlinkWebView.h"
+#include "BlinkWebViewProfileHelper.h"
 #include "LogManager.h"
 #include "PalmSystemBlink.h"
 #include "WebAppManagerConfig.h"
@@ -103,6 +104,9 @@ void WebPageBlink::init()
 {
     d->pageView = createPageView();
     d->pageView->setDelegate(this);
+    webos::WebViewProfile* profile = BlinkWebViewProfileHelper::instance()->getProfile(m_appDesc->id());
+    if (profile)
+        d->pageView->SetProfile(profile);
     d->pageView->Initialize(m_appDesc->id(),
                             m_appDesc->folderPath(),
                             m_appDesc->trustLevel(),


### PR DESCRIPTION
Previously, the default profile was being used for all web apps. As a
result of this, the proxy rules where being shared by all web apps, and
the same tinyproxy process would be used by all of them. SMACK would
then block tinyproxy requests for all web apps but the first one, which
would be the one that configured the SMACK label in the tinyproxy
process.

Now, a mapping between app ids and WebView profiles is stored and
applied to each WebView. The proxy rules are stored on those profiles.

[SPEC-1895] error launching web app: "tinyproxy was unable to connect to the remote web server"
https://jira.automotivelinux.org/browse/SPEC-1895