### PR TITLE
[agl][qtless] Drop WebAppFactory pluggable system

### DIFF
--- a/src/agl/WebAppFactoryAGL.cpp
+++ b/src/agl/WebAppFactoryAGL.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2014-2018 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "WebAppFactoryAGL.h"
+
+#include "ApplicationDescription.h"
+#include "WebAppWaylandAGL.h"
+#include "WebPageBase.h"
+#include "WebAppBase.h"
+#include "WebAppWayland.h"
+#include "WebPageBlink.h"
+#include "WindowTypes.h"
+#include "LogManager.h"
+
+#include <QString>
+
+WebAppBase* WebAppFactoryAGL::createWebApp(QString winType, ApplicationDescription* desc)
+{
+    WebAppBase* app = 0;
+
+    if(winType == WT_CARD || winType == WT_POPUP || winType == WT_MINIMAL || winType == WT_FLOATING) {
+        app = new WebAppWaylandAGL(winType, desc);
+    } else if(winType == WT_OVERLAY) {
+        app = new WebAppWayland(winType, desc->surfaceId());
+    } else if(winType == WT_SYSTEM_UI) {
+        app = new WebAppWayland(winType, desc->surfaceId());
+    } else if(winType == WT_NONE) {
+        app = new WebAppWayland(winType, desc->surfaceId());
+    } else {
+        LOG_WARNING(MSGID_BAD_WINDOW_TYPE, 1,
+                    PMLOGKS("WINDOW_TYPE", qPrintable(winType)), "");
+    }
+    return app;
+}
+
+WebAppBase* WebAppFactoryAGL::createWebApp(QString winType, WebPageBase* page, ApplicationDescription* desc)
+{
+    return createWebApp(winType, desc);
+}
+
+WebPageBase* WebAppFactoryAGL::createWebPage(QUrl url, ApplicationDescription* desc, QString launchParams)
+{
+    return new WebPageBlink(url, desc, launchParams);
+}
+

--- a/src/agl/WebAppFactoryAGL.h
+++ b/src/agl/WebAppFactoryAGL.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2014-2018 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef WEBAPPFACTORYAGL_H
+#define WEBAPPFACTORYAGL_H
+
+#include "WebAppFactoryInterface.h"
+
+#include <QtCore/QUrl>
+
+class WebAppFactoryAGL : public WebAppFactoryInterface {
+public:
+    virtual WebAppBase* createWebApp(QString winType, ApplicationDescription* desc = 0);
+    virtual WebAppBase* createWebApp(QString winType, WebPageBase* page, ApplicationDescription* desc = 0);
+    virtual WebPageBase* createWebPage(QUrl url, ApplicationDescription* desc, QString launchParams = "");
+};
+
+#endif /* WEBAPPFACTORYAGL_H */

--- a/src/agl/WebAppFactoryManagerAGL.cpp
+++ b/src/agl/WebAppFactoryManagerAGL.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2008-2018 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "WebAppFactoryManager.h"
+
+#include "LogManager.h"
+#include "WebAppBase.h"
+#include "WebAppFactoryAGL.h"
+#include "WebAppManagerConfig.h"
+#include "WebAppManager.h"
+#include "WebPageBase.h"
+
+class WebAppFactoryManagerAGL : public WebAppFactoryManager {
+protected:
+    virtual WebAppFactoryInterface* loadInterfaceInstance(QString appType);
+
+private:
+    friend class WebAppFactoryManager;
+    WebAppFactoryManagerAGL();
+
+    WebAppFactoryInterface *m_defaultInterface;
+};
+
+WebAppFactoryManager* WebAppFactoryManager::instance()
+{
+    if(!m_instance) {
+        m_instance = new WebAppFactoryManagerAGL();
+    }
+    return m_instance;
+}
+
+WebAppFactoryManagerAGL::WebAppFactoryManagerAGL()
+    : m_defaultInterface(new WebAppFactoryAGL())
+{
+    m_interfaces.insert(kDefaultAppType, m_defaultInterface);
+}
+
+WebAppFactoryInterface* WebAppFactoryManagerAGL::loadInterfaceInstance(QString appType)
+{
+    if (!appType.isEmpty())
+        return nullptr;
+
+    return m_defaultInterface;
+}
+

--- a/src/agl/WebAppWaylandAGL.cpp
+++ b/src/agl/WebAppWaylandAGL.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2008-2018 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "WebAppWaylandAGL.h"
+#include "ApplicationDescription.h"
+
+WebAppWaylandAGL::WebAppWaylandAGL(QString& winType, ApplicationDescription* desc)
+    : WebAppWayland(winType, desc->surfaceId(), desc->widthOverride(), desc->heightOverride())
+{
+}

--- a/src/agl/WebAppWaylandAGL.h
+++ b/src/agl/WebAppWaylandAGL.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2008-2018 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef WEBAPPWAYLANDAGL_H
+#define WEBAPPWAYLANDAGL_H
+
+#include "WebAppWayland.h"
+
+class ApplicationDescription;
+
+class WebAppWaylandAGL : public WebAppWayland {
+public:
+    WebAppWaylandAGL(QString& winType, ApplicationDescription* desc = 0);
+};
+
+#endif /* WEBAPPWAYLANDAGL_H */

--- a/src/core/WebAppFactoryManager.cpp
+++ b/src/core/WebAppFactoryManager.cpp
@@ -16,13 +16,6 @@
 
 #include "WebAppFactoryManager.h"
 
-#include <QtCore/QDir>
-#include <QtCore/QPluginLoader>
-
-// FIXME: Remove once WebAppFactory pluggable system is dropped.
-#include <QtCore/QJsonArray>
-#include <QtCore/QJsonObject>
-
 #include "LogManager.h"
 #include "WebAppBase.h"
 #include "WebAppManagerConfig.h"
@@ -31,78 +24,22 @@
 
 WebAppFactoryManager* WebAppFactoryManager::m_instance = NULL;
 
-WebAppFactoryManager* WebAppFactoryManager::instance()
+WebAppFactoryManager::~WebAppFactoryManager()
 {
-    if(!m_instance) {
-        m_instance = new WebAppFactoryManager();
-    }
-    return m_instance;
 }
 
-WebAppFactoryManager::WebAppFactoryManager()
-    : m_loadPluggableOnDemand(false)
-{
-    WebAppManagerConfig* webAppManagerConfig = WebAppManager::instance()->config();
-
-    QString factoryEnv = webAppManagerConfig->getWebAppFactoryPluginTypes();
-    m_factoryEnv = factoryEnv.split(QLatin1Char(':'));
-    m_factoryEnv.append(QStringLiteral("default"));
-
-    m_webAppFactoryPluginPath = webAppManagerConfig->getWebAppFactoryPluginPath();
-
-    if (webAppManagerConfig->isDynamicPluggableLoadEnabled())
-        m_loadPluggableOnDemand = true;
-
-    if (!m_loadPluggableOnDemand)
-        loadPluggable();
-}
-
-WebAppFactoryInterface* WebAppFactoryManager::getPluggable(QString appType)
+WebAppFactoryInterface* WebAppFactoryManager::getInterfaceInstance(QString appType)
 {
     QMap<QString, WebAppFactoryInterface*>::iterator iter = m_interfaces.find(appType);
     if (iter != m_interfaces.end())
         return iter.value();
 
-    return loadPluggable(appType);
-}
-
-WebAppFactoryInterface* WebAppFactoryManager::loadPluggable(QString appType)
-{
-    if (!appType.isEmpty() && !m_factoryEnv.contains(appType))
-        return 0;
-
-    WebAppFactoryInterface* interface;
-    QDir pluginsDir(m_webAppFactoryPluginPath);
-
-    // FIXME: Remove once WebAppFactory pluggable system is dropped.
-    Q_FOREACH (QString fileName, pluginsDir.entryList(QDir::Files)) {
-        QPluginLoader pluginLoader(pluginsDir.absoluteFilePath(fileName));
-        QString key = pluginLoader.metaData().value("MetaData").toObject().value("Keys").toArray().at(0).toString();
-
-        if (key.contains(appType) || !m_loadPluggableOnDemand) {
-            QObject *plugin = pluginLoader.instance();
-
-            if (plugin) {
-                interface = qobject_cast<WebAppFactoryInterface*>(plugin);
-                if (interface)
-                    m_interfaces.insert(key, interface);
-                if (!appType.isEmpty())
-                    return interface;
-            } else {
-                LOG_WARNING(MSGID_PLUGIN_LOAD_FAIL, 1, PMLOGKS("ERROR", pluginLoader.errorString().toStdString().c_str()), "");
-                if (pluginLoader.isLoaded())
-                    pluginLoader.unload();
-                if (!appType.isEmpty())
-                    return 0;
-            }
-        }
-    }
-    return 0;
+    return loadInterfaceInstance(appType);
 }
 
 WebAppBase* WebAppFactoryManager::createWebApp(QString winType, ApplicationDescription* desc, QString appType)
 {
-    WebAppFactoryInterface* interface = getPluggable(appType);
+    WebAppFactoryInterface* interface = getInterfaceInstance(appType);
     if (interface)
         return interface->createWebApp(winType, desc);
 
@@ -111,7 +48,7 @@ WebAppBase* WebAppFactoryManager::createWebApp(QString winType, ApplicationDescr
 
 WebAppBase* WebAppFactoryManager::createWebApp(QString winType, WebPageBase* page, ApplicationDescription* desc, QString appType)
 {
-    WebAppFactoryInterface* interface = getPluggable(appType);  
+    WebAppFactoryInterface* interface = getInterfaceInstance(appType);
     if (interface)
         return interface->createWebApp(winType, page, desc);
 
@@ -122,13 +59,13 @@ WebPageBase* WebAppFactoryManager::createWebPage(QString winType, QUrl url, Appl
 {
     WebPageBase *page = NULL;
 
-    WebAppFactoryInterface* interface = getPluggable(appType);
+    WebAppFactoryInterface* interface = getInterfaceInstance(appType);
     if (interface) {
         page = interface->createWebPage(url, desc, launchParams);
     } else {
         // use default factory if cannot find appType.
-        if (m_interfaces.find("default") != m_interfaces.end())
-            page = m_interfaces.value("default")->createWebPage(url, desc, launchParams);
+        if (m_interfaces.find(kDefaultAppType) != m_interfaces.end())
+            page = m_interfaces.value(kDefaultAppType)->createWebPage(url, desc, launchParams);
     }
 
     if (page) page->init();

--- a/src/core/WebAppFactoryManager.h
+++ b/src/core/WebAppFactoryManager.h
@@ -22,22 +22,24 @@
 
 #include "WebAppFactoryInterface.h"
 
+static const QString kDefaultAppType = QStringLiteral("default");
+
 class WebAppFactoryManager {
 public:
     static WebAppFactoryManager* instance();
+    virtual ~WebAppFactoryManager();
     WebAppBase* createWebApp(QString winType, ApplicationDescription* desc = 0, QString appType = "");
     WebAppBase* createWebApp(QString winType, WebPageBase* page, ApplicationDescription* desc = 0, QString appType = "");
     WebPageBase* createWebPage(QString winType, QUrl url, ApplicationDescription* desc, QString appType = "", QString launchParams = "");
-    WebAppFactoryInterface* getPluggable(QString appType);
-    WebAppFactoryInterface* loadPluggable(QString appType = "");
+    WebAppFactoryInterface* getInterfaceInstance(QString appType);
+
+protected:
+    WebAppFactoryManager() {}
+    virtual WebAppFactoryInterface* loadInterfaceInstance(QString appType) = 0;
+    QMap<QString, WebAppFactoryInterface*> m_interfaces;
 
 private:
     static WebAppFactoryManager* m_instance;
-    WebAppFactoryManager();
-    QMap<QString, WebAppFactoryInterface*> m_interfaces;
-    QString m_webAppFactoryPluginPath;
-    QStringList m_factoryEnv;
-    bool m_loadPluggableOnDemand;
 };
 
 #endif /* WEBAPPFACTORY_H */

--- a/src/plugin/WebAppFactoryManagerQtPlugin.cpp
+++ b/src/plugin/WebAppFactoryManagerQtPlugin.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2008-2018 LG Electronics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "WebAppFactoryManager.h"
+
+#include <QtCore/QDir>
+#include <QtCore/QPluginLoader>
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonObject>
+
+#include "LogManager.h"
+#include "WebAppBase.h"
+#include "WebAppManagerConfig.h"
+#include "WebAppManager.h"
+#include "WebPageBase.h"
+
+class WebAppFactoryManagerQtPlugin : public WebAppFactoryManager {
+protected:
+    virtual WebAppFactoryInterface* loadInterfaceInstance(QString appType);
+
+private:
+    friend class WebAppFactoryManager;
+    WebAppFactoryManagerQtPlugin();
+
+    QString m_webAppFactoryPluginPath;
+    QStringList m_factoryEnv;
+    bool m_loadPluggableOnDemand;
+};
+
+WebAppFactoryManager* WebAppFactoryManager::instance()
+{
+    if(!m_instance) {
+        m_instance = new WebAppFactoryManagerQtPlugin();
+    }
+    return m_instance;
+}
+
+WebAppFactoryManagerQtPlugin::WebAppFactoryManagerQtPlugin()
+    : m_loadPluggableOnDemand(false)
+{
+    WebAppManagerConfig* webAppManagerConfig = WebAppManager::instance()->config();
+
+    QString factoryEnv = webAppManagerConfig->getWebAppFactoryPluginTypes();
+    m_factoryEnv = factoryEnv.split(QLatin1Char(':'));
+    m_factoryEnv.append(kDefaultAppType);
+
+    m_webAppFactoryPluginPath = webAppManagerConfig->getWebAppFactoryPluginPath();
+
+    if (webAppManagerConfig->isDynamicPluggableLoadEnabled())
+        m_loadPluggableOnDemand = true;
+
+    if (!m_loadPluggableOnDemand)
+        loadInterfaceInstance({});
+}
+
+WebAppFactoryInterface* WebAppFactoryManagerQtPlugin::loadInterfaceInstance(QString appType)
+{
+    if (!appType.isEmpty() && !m_factoryEnv.contains(appType))
+        return nullptr;
+
+    WebAppFactoryInterface* interface;
+    QDir pluginsDir(m_webAppFactoryPluginPath);
+
+    Q_FOREACH (QString fileName, pluginsDir.entryList(QDir::Files)) {
+        QPluginLoader pluginLoader(pluginsDir.absoluteFilePath(fileName));
+        QString key = pluginLoader.metaData().value("MetaData").toObject().value("Keys").toArray().at(0).toString();
+
+        if (key.contains(appType) || !m_loadPluggableOnDemand) {
+            QObject *plugin = pluginLoader.instance();
+
+            if (plugin) {
+                interface = qobject_cast<WebAppFactoryInterface*>(plugin);
+                if (interface)
+                    m_interfaces.insert(key, interface);
+                if (!appType.isEmpty())
+                    return interface;
+            } else {
+                LOG_WARNING(MSGID_PLUGIN_LOAD_FAIL, 1, PMLOGKS("ERROR", pluginLoader.errorString().toStdString().c_str()), "");
+                if (pluginLoader.isLoaded())
+                    pluginLoader.unload();
+                if (!appType.isEmpty())
+                    return nullptr;
+            }
+        }
+    }
+    return nullptr;
+}
+

--- a/wam.pro
+++ b/wam.pro
@@ -22,4 +22,8 @@ wamlib.file = wamlib.pri
 wamplugin.file = wamplugin.pri
 wam.file = wam.pri
 
-SUBDIRS += wamcorelib wamlib wamplugin wam
+SUBDIRS += wamcorelib wamlib
+luna_service {
+    SUBDIRS += wamplugin
+}
+SUBDIRS += wam

--- a/wamcorelib.pri
+++ b/wamcorelib.pri
@@ -68,6 +68,16 @@ HEADERS += \
         WebRuntime.h \
         WindowTypes.h
 
+luna_service {
+    SOURCES += \
+        WebAppFactoryManagerQtPlugin.cpp
+}
+
+agl_service {
+    SOURCES += \
+        WebAppFactoryManagerAGL.cpp
+}
+
 pmlog {
     SOURCES += LogManagerPmLog.cpp
     HEADERS += LogManagerPmLog.h

--- a/wamlib.pri
+++ b/wamlib.pri
@@ -72,9 +72,13 @@ luna_service {
 agl_service {
     SOURCES += \
             WebAppManagerServiceAGL.cpp \
+            WebAppFactoryAGL.cpp \
+            WebAppWaylandAGL.cpp \
             WebRuntimeAGL.cpp
     HEADERS += \
             WebAppManagerServiceAGL.h \
+            WebAppFactoryAGL.h \
+            WebAppWaylandAGL.h \
             WebRuntimeAGL.h
 }
 


### PR DESCRIPTION
As part of Qt-less effort, this patch drops WAM's Qt-based
Pluggable WebAppFactory system (at least temporarily) for AGL
build. To achieve it, (if agl_service build flag is set) we now
compile plugin/* files and link them to libWebAppMngr and
instantiate a WebAppFactoryLuna object into WebAppFactoryManager
in order to statically handle WebApps with "default" app type.

[SPEC-1913] Qt-less WAM: drop Qt plugin usage
[SPEC-1871] [meta] Qt-less WAM

Signed-off-by: Nick Diego Yamane <nickdiego@igalia.com>