### PR TITLE
Set initial size for AGL

### DIFF
--- a/files/launch/WebAppMgr.env
+++ b/files/launch/WebAppMgr.env
@@ -49,6 +49,10 @@ WAM_RESOURCE_BUFFER_MAX_ALLOC_SIZE=262144
 # setup 1 Mb for resource buffer
 WAM_RESOURCE_BUFFER_SIZE=1048576
 
+# Set the initial window size
+# The current value is the window size on AGL.
+WAM_WINDOW_SIZE=608,837
+
 # setup 200 seconds for watchdog timeout of render process
 WATCHDOG_RENDER_TIMEOUT=200
 

--- a/src/core/ApplicationDescription.cpp
+++ b/src/core/ApplicationDescription.cpp
@@ -24,6 +24,32 @@
 #include "ApplicationDescription.h"
 #include "JsonHelper.h"
 #include "LogManager.h"
+#include "WebAppManagerConfig.h"
+#include "WebAppManager.h"
+
+static void getWindowSizeFromConfig(int& widthOutput, int& heightOutput) {
+    WebAppManagerConfig* webAppManagerConfig = WebAppManager::instance()->config();
+
+    if (!webAppManagerConfig) {
+        fprintf(stderr, "Failed to get webAppManagerConfig\r\n");
+        return;
+    }
+
+    std::string windowSize = webAppManagerConfig->getWindowSize();
+    if (windowSize.empty())
+        return;
+
+    std::size_t pos = windowSize.find(",");
+    if (pos == std::string::npos) {
+        fprintf(stderr, "Not matched with size format, 'w,h'.\r\n");
+        return;
+    }
+
+    std::string width = windowSize.substr(0, pos);
+    std::string height = windowSize.substr(pos+1);
+    widthOutput = std::stoi(width);
+    heightOutput = std::stoi(height);
+}
 
 bool ApplicationDescription::checkTrustLevel(std::string trustLevel)
 {
@@ -55,6 +81,7 @@ ApplicationDescription::ApplicationDescription()
     , m_networkStableTimeout(std::numeric_limits<double>::quiet_NaN())
     , m_disallowScrollingInMainFrame(true)
 {
+    getWindowSizeFromConfig(m_widthOverride, m_heightOverride);
 }
 
 const ApplicationDescription::WindowGroupInfo ApplicationDescription::getWindowGroupInfo()

--- a/src/core/WebAppManagerConfig.cpp
+++ b/src/core/WebAppManagerConfig.cpp
@@ -17,6 +17,7 @@
 #include "WebAppManagerConfig.h"
 
 #include <unistd.h>
+#include <cstdlib>
 
 WebAppManagerConfig::WebAppManagerConfig()
     : m_suspendDelayTime(0)
@@ -73,6 +74,8 @@ void WebAppManagerConfig::initConfiguration()
         m_userScriptPath = QLatin1String("webOSUserScripts/userScript.js");
 
     m_name = qgetenv("WAM_NAME").data();
+
+    m_windowSize = std::getenv("WAM_WINDOW_SIZE");
 }
 
 QVariant WebAppManagerConfig::getConfiguration(QString name)

--- a/src/core/WebAppManagerConfig.h
+++ b/src/core/WebAppManagerConfig.h
@@ -42,6 +42,7 @@ public:
     virtual bool isUseSystemAppOptimization() const { return m_useSystemAppOptimization; }
     virtual QString getUserScriptPath() const { return m_userScriptPath; }
     virtual std::string getName() const { return m_name; }
+    virtual std::string getWindowSize() const { return m_windowSize; }
 
     virtual bool isLaunchOptimizationEnabled() const { return m_launchOptimizationEnabled; }
 
@@ -68,6 +69,7 @@ private:
     bool m_launchOptimizationEnabled;
     QString m_userScriptPath;
     std::string m_name;
+    std::string m_windowSize;
 
     QMap<QString, QVariant> m_configuration;
 };

--- a/src/platform/webengine/BlinkWebView.cpp
+++ b/src/platform/webengine/BlinkWebView.cpp
@@ -20,8 +20,8 @@
 #include "LogManager.h"
 #include <QStringList>
 
-BlinkWebView::BlinkWebView(bool doInitialize)
-    : WebViewBase::WebViewBase()
+BlinkWebView::BlinkWebView(int width, int height, bool doInitialize)
+    : WebViewBase::WebViewBase(width, height)
     , m_delegate(NULL)
     , m_progress(0)
     , m_userScriptExecuted(false)

--- a/src/platform/webengine/BlinkWebView.h
+++ b/src/platform/webengine/BlinkWebView.h
@@ -26,7 +26,7 @@ class WebPageBlinkDelegate;
 class BlinkWebView : public webos::WebViewBase {
 public:
     // TODO need to refactor both constructors (here & pluggables)
-    BlinkWebView(bool doInitialize = true);
+    BlinkWebView(int width = 1920, int height = 1080, bool doInitialize = true);
     BlinkWebView(const QString& group)
         : BlinkWebView()
     {

--- a/src/platform/webengine/WebPageBlink.cpp
+++ b/src/platform/webengine/WebPageBlink.cpp
@@ -101,7 +101,7 @@ WebPageBlink::~WebPageBlink()
 
 void WebPageBlink::init()
 {
-    d->pageView = createPageView();
+    d->pageView = createPageView(m_appDesc->widthOverride(), m_appDesc->heightOverride());
     d->pageView->setDelegate(this);
     d->pageView->Initialize(m_appDesc->id(),
                             m_appDesc->folderPath(),
@@ -778,9 +778,9 @@ void WebPageBlink::didFinishLaunchingSlot()
 }
 
 // functions from webappmanager2
-BlinkWebView * WebPageBlink::createPageView()
+BlinkWebView * WebPageBlink::createPageView(int width, int height)
 {
-    return new BlinkWebView();
+    return new BlinkWebView(width, height);
 }
 
 BlinkWebView* WebPageBlink::pageView() const

--- a/src/platform/webengine/WebPageBlink.h
+++ b/src/platform/webengine/WebPageBlink.h
@@ -154,7 +154,7 @@ protected:
     // WebPageBase
     virtual void loadDefaultUrl();
     virtual void loadErrorPage(int errorCode);
-    virtual BlinkWebView* createPageView();
+    virtual BlinkWebView* createPageView(int width, int height);
     virtual void setupStaticUserScripts();
     virtual void addUserScript(const QString& script);
     virtual void addUserScriptUrl(const QUrl& url);


### PR DESCRIPTION
It sets initial values for App size with AGL window size. It
couldn't get the AGL window size for now as Window manager doesn't
support that functionality for now. So, it sets the default values
for m_widthOverride and m_heightOverride as these values delivers
to WebView size and window size.

[SPEC-1890] WebApp View Size doesn't fit the homescreen.
https://jira.automotivelinux.org/browse/SPEC-1890