### PR TITLE
Start wam as systemd user service correcting its dependencies

### DIFF
--- a/files/launch/WebAppMgr.service
+++ b/files/launch/WebAppMgr.service
@@ -12,8 +12,8 @@
 
 [Unit]
 Description="WebAppMgr is responsible for running web apps and manage their lifecycle"
-Requires=weston.service
-After=weston.service
+After=afm-service-windowmanager-service-2017@0.1.service afm-appli-homescreen-2017@0.1.service
+Wants=afm-service-windowmanager-service-2017@0.1.service afm-appli-homescreen-2017@0.1.service
 
 [Service]
 Type=simple
@@ -24,4 +24,4 @@ Restart=on-failure
 RestartSec=50
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
wam systemd scripts were waiting for weston to launch. But this is
not enough, as for proper integration with AGL window manager and
homescreen it is using those services. So wam should wait for those
services.

[SPEC-1944] WAM: service fails to start upon very first boot after flashing
https://jira.automotivelinux.org/browse/SPEC-1944