### PR TITLE
[agl][jsonpp] Fix jsoncpp warnings when opening webapps

### DIFF
--- a/src/core/ApplicationDescription.cpp
+++ b/src/core/ApplicationDescription.cpp
@@ -169,7 +169,6 @@ ApplicationDescription* ApplicationDescription::fromJsonString(const char* jsonS
 
     appDesc->m_surfaceId = jsonObj["surfaceId"].asInt();
     appDesc->m_transparency = jsonObj["transparent"].asBool();
-    appDesc->m_vendorExtension = jsonObj["vendorExtension"].toStyledString();
     appDesc->m_trustLevel = jsonObj["trustLevel"].asString();
     appDesc->m_subType = jsonObj["subType"].asString();
     appDesc->m_deeplinkingParams = jsonObj["deeplinkingParams"].asString();
@@ -183,7 +182,11 @@ ApplicationDescription* ApplicationDescription::fromJsonString(const char* jsonS
     appDesc->m_version = jsonObj["version"].asString();
     appDesc->m_customPlugin = jsonObj["customPlugin"].asBool();
     appDesc->m_backHistoryAPIDisabled = jsonObj["disableBackHistoryAPI"].asBool();
-    appDesc->m_groupWindowDesc = jsonObj["windowGroup"].toStyledString();
+
+    auto vendorExtension = jsonObj.get("vendorExtension", Json::Value(Json::objectValue));
+    auto groupWindowDesc = jsonObj.get("windowGroup", Json::Value(Json::objectValue));
+    dumpJsonToString(vendorExtension, appDesc->m_vendorExtension);
+    dumpJsonToString(groupWindowDesc, appDesc->m_groupWindowDesc);
 
     auto supportedVersions = jsonObj["supportedEnyoBundleVersions"];
     if (supportedVersions.isArray()) {

--- a/src/util/JsonHelper.cpp
+++ b/src/util/JsonHelper.cpp
@@ -16,6 +16,7 @@
 
 #include "JsonHelper.h"
 
+#include <iostream>
 #include <memory>
 #include <fstream>
 #include <sstream>
@@ -23,42 +24,53 @@
 #include <json/reader.h>
 #include <json/writer.h>
 
-#include "LogManager.h"
+using std::cerr;
+using std::endl;
 
-// TODO: Log error/warn messages when something wrong happens(?)
+#define LOGE cerr << __PRETTY_FUNCTION__ << ": "
+
 bool readJsonFromString(const std::string &in, Json::Value& out) {
+    out = Json::nullValue;
+    if (in.empty())
+        return true;
     Json::Value jsonObj;
     try {
         std::istringstream(in) >> jsonObj;
-    } catch (const Json::RuntimeError &) {
+        out = std::move(jsonObj);
+        return true;
+    } catch (const Json::RuntimeError &e) {
+        LOGE << " Failed to parse: " << e.what() << endl;
         return false;
     }
-    out = jsonObj;
-    return true;
 }
 
 bool readJsonFromFile(const std::string &path, Json::Value& out) {
+    out = Json::nullValue;
     std::ifstream in(path);
     if (!in.is_open()) {
+        LOGE << " Failed to open file " << path << endl;
         return false;
     }
     Json::Value jsonObj;
     try {
         in >> jsonObj;
-    } catch (const Json::RuntimeError &) {
+        out = std::move(jsonObj);
+        return true;
+    } catch (const Json::RuntimeError &e) {
+        LOGE << " Failed to parse: " << e.what() << endl;
         return false;
     }
-    out = jsonObj;
-    return true;
 }
 
 // FIXME: Using default writter settings for now (e.g: indentation
 // enable, etc).
 bool dumpJsonToString(const Json::Value &json, std::string &out) {
+    out = {};
     std::stringstream ss;
     try {
         ss << json;
-    } catch (const Json::RuntimeError &) {
+    } catch (const Json::RuntimeError &e) {
+        LOGE << " Failed to dump: " << e.what() << endl;
         return false;
     }
     out = ss.str();


### PR DESCRIPTION
- Those warnings were actually from jsoncpp version 1.8.3, but this patch
improve empty string handling and fixes nested object serialization to work
just like previous Qt-based version.

- I verified this patches as much as I could using qemu build, which maybe is
not enough because WAM crashes at some point when opening memorymatch,
for example. Anyway I could verify that the warnings don't appear anymore.

[SPEC-1941] WAM: jsoncpp shows warnings opening applications in log