### PR TITLE
[agl/qtless] Get rid of Qt signals/slots usage

### DIFF
--- a/src/core/WebAppBase.cpp
+++ b/src/core/WebAppBase.cpp
@@ -220,7 +220,7 @@ void WebAppBase::closeAppInternal()
 
 void WebAppBase::attach(WebPageBase* page)
 {
-    // connect to the signals of the WebBridge
+    // start observing the WebPage
     // parse up the ApplicationDescription
     if (d->m_page)
         detach();
@@ -229,9 +229,6 @@ void WebAppBase::attach(WebPageBase* page)
     d->m_page->createPalmSystem(this);
 
     observe(d->m_page);
-    connect(d->m_page, SIGNAL(webPageUrlChanged()), this, SLOT(webPageUrlChangedSlot()));
-    connect(d->m_page, SIGNAL(webPageLoadFinished()), this, SLOT(webPageLoadFinishedSlot()));
-    connect(d->m_page, SIGNAL(webPageLoadFailed(int)), this, SLOT(webPageLoadFailedSlot(int)));
     d->createActivity();
 }
 
@@ -239,7 +236,6 @@ WebPageBase* WebAppBase::detach(void)
 {
     WebPageBase* p = d->m_page;
 
-    disconnect(d->m_page, 0, this, 0);
     unobserve(d->m_page);
 
     d->m_page = 0;
@@ -304,7 +300,7 @@ void WebAppBase::relaunch(const QString& args, const QString& launchingAppId)
     }
 }
 
-void WebAppBase::webPageLoadFinishedSlot()
+void WebAppBase::webPageLoadFinished()
 {
     doPendingRelaunch();
 }
@@ -323,7 +319,7 @@ void WebAppBase::doPendingRelaunch()
     }
 }
 
-void WebAppBase::webPageClosePageRequestedSlot()
+void WebAppBase::webPageClosePageRequested()
 {
     LOG_INFO(MSGID_WINDOW_CLOSED_JS, 2, PMLOGKS("APP_ID", qPrintable(appId())), PMLOGKFV("PID", "%d", page()->getWebProcessPID()), "");
     WebAppManager::instance()->closeApp(appId().toStdString());
@@ -349,11 +345,6 @@ void WebAppBase::showWindow()
     // Set the accessibility after the application launched
     // because the chromium can generate huge amount of AXEvent during app loading.
     setUseAccessibility(WebAppManager::instance()->isAccessibilityEnabled());
-}
-
-void WebAppBase::showWindowSlot()
-{
-    showWindow();
 }
 
 void WebAppBase::setAppDescription(ApplicationDescription* appDesc)
@@ -462,11 +453,6 @@ void WebAppBase::setUiSize(int width, int height) {
     WebAppManager::instance()->setUiSize(width, height);
 }
 
-void WebAppBase::webPageUrlChangedSlot()
-{
-    d->m_url = d->m_page->url().toString();
-}
-
 void WebAppBase::setPreferredLanguages(QString language)
 {
     if (!d->m_page)
@@ -503,14 +489,31 @@ void WebAppBase::setUseAccessibility(bool enabled)
 
 void WebAppBase::executeCloseCallback()
 {
-    connect(d->m_page, SIGNAL(closeCallbackExecuted()),this, SLOT(closeWebAppSlot()));
-    connect(d->m_page, SIGNAL(timeoutExecuteCloseCallback()),this, SLOT(closeWebAppSlot()));
-    connect(d->m_page, SIGNAL(closingAppProcessDidCrashed()),this, SLOT(closeWebAppSlot()));
     page()->executeCloseCallback(forceClose());
     LOG_INFO(MSGID_EXECUTE_CLOSECALLBACK, 2, PMLOGKS("APP_ID", qPrintable(appId())), PMLOGKFV("PID", "%d", page()->getWebProcessPID()), "");
 }
 
-void WebAppBase::closeWebAppSlot()
+void WebAppBase::closeCallbackExecuted()
+{
+	closeWebApp();
+}
+
+void WebAppBase::timeoutExecuteCloseCallback()
+{
+	closeWebApp();
+}
+
+void WebAppBase::closingAppProcessDidCrashed()
+{
+	closeWebApp();
+}
+
+void WebAppBase::didDispatchUnload()
+{
+	closeWebApp();
+}
+
+void WebAppBase::closeWebApp()
 {
     LOG_INFO(MSGID_CLEANRESOURCE_COMPLETED, 2, PMLOGKS("APP_ID", qPrintable(appId())), PMLOGKFV("PID", "%d", page()->getWebProcessPID()), "closeCallback/about:blank is DONE");
     WebAppManager::instance()->removeClosingAppList(appId());
@@ -524,8 +527,6 @@ void WebAppBase::closeWebAppSlot()
 
 void WebAppBase::dispatchUnload()
 {
-    connect(d->m_page, SIGNAL(didDispatchUnload()),this, SLOT(closeWebAppSlot()));
-    connect(d->m_page, SIGNAL(closingAppProcessDidCrashed()),this, SLOT(closeWebAppSlot()));
     page()->cleanResources();
 }
 

--- a/src/core/WebAppBase.h
+++ b/src/core/WebAppBase.h
@@ -31,10 +31,7 @@ class ApplicationDescription;
 class WebAppBasePrivate;
 class WebPageBase;
 
-class WebAppBase : public QObject,
-                   public WebPageObserver {
-
-    Q_OBJECT
+class WebAppBase : public WebPageObserver {
 
 public:
     enum PreloadState {
@@ -128,6 +125,15 @@ public:
 
     bool isClosing() const;
     bool isCheckLaunchTimeEnabled();
+    void closeWebApp();
+
+    // WebPageObserver
+    virtual void webPageLoadFinished();
+    virtual void webPageClosePageRequested();
+    virtual void closeCallbackExecuted();
+    virtual void timeoutExecuteCloseCallback();
+    virtual void closingAppProcessDidCrashed();
+    virtual void didDispatchUnload();
 
 protected:
     virtual void doAttach() = 0;
@@ -137,14 +143,6 @@ protected:
     void setActiveAppId(QString id);
     void forceCloseAppInternal();
     void closeAppInternal();
-
-protected Q_SLOTS:
-    virtual void webPageUrlChangedSlot();
-    virtual void webPageClosePageRequestedSlot();
-    virtual void showWindowSlot();
-    virtual void webPageLoadFinishedSlot();
-    virtual void webPageLoadFailedSlot(int errorCode) = 0;
-    virtual void closeWebAppSlot();
 
 protected:
     PreloadState m_preloadState;

--- a/src/core/WebPageBase.cpp
+++ b/src/core/WebPageBase.cpp
@@ -240,11 +240,6 @@ void WebPageBase::sendRelaunchEvent()
         "}, 1);").arg(launchParams().isEmpty() ? "{}" : launchParams()));
 }
 
-void WebPageBase::urlChangedSlot()
-{
-    Q_EMIT webPageUrlChanged();
-}
-
 void WebPageBase::handleLoadStarted()
 {
     m_suspendAtLoad = true;
@@ -336,11 +331,6 @@ int WebPageBase::suspendDelay()
 QString WebPageBase::telluriumNubPath()
 {
     return getWebAppManagerConfig()->getTelluriumNubPath();
-}
-
-void WebPageBase::doLoadSlot()
-{
-    loadDefaultUrl();
 }
 
 bool WebPageBase::hasLoadErrorPolicy(bool isHttpResponseError, int errorCode)

--- a/src/core/WebPageBase.cpp
+++ b/src/core/WebPageBase.cpp
@@ -251,7 +251,7 @@ void WebPageBase::handleLoadFinished()
     if (appId() == WebAppManager::instance()->getContainerAppId())
         WebAppManager::instance()->setContainerAppLaunched(true);
 
-    Q_EMIT webPageLoadFinished();
+    FOR_EACH_OBSERVER(WebPageObserver, m_observers, webPageLoadFinished());
 
     // if there was an attempt made to suspend while this page was loading, then
     // we flag m_suspendAtLoad = true, and suspend it after it is loaded. This is

--- a/src/core/WebPageBase.h
+++ b/src/core/WebPageBase.h
@@ -149,11 +149,6 @@ Q_SIGNALS:
     void closingAppProcessDidCrashed();
     void didDispatchUnload();
 
-protected Q_SLOTS:
-    virtual void urlChangedSlot();
-    void doLoadSlot();
-    virtual void suspendWebPagePaintingAndJSExecution() = 0;
-
 protected:
     // WebPageBase
     virtual void cleanResourcesFinished();
@@ -167,6 +162,7 @@ protected:
     virtual void recreateWebView() = 0;
     virtual void setVisible(bool visible) {}
     virtual bool doDeeplinking(const QString& launchParams);
+    virtual void suspendWebPagePaintingAndJSExecution() = 0;
 
     void handleLoadStarted();
     void handleLoadFinished();

--- a/src/core/WebPageBase.h
+++ b/src/core/WebPageBase.h
@@ -35,9 +35,7 @@ class WebProcessManager;
  * Common base class for UI independent
  * web page functionality
  */
-class WebPageBase : public QObject {
-    Q_OBJECT
-
+class WebPageBase {
 public:
     // Originally, webview_base.h, WebPageVisibilityState.h, PageVisibilityState.h
     // we can use enum of webview_base.h directly but this is WebPageBase in core
@@ -139,15 +137,6 @@ public:
     void removeObserver(WebPageObserver* observer);
 
     static QString truncateURL(const QString& url);
-
-Q_SIGNALS:
-    void webPageUrlChanged();
-    void webPageLoadFinished();
-    void webPageLoadFailed(int errorCode);
-    void closeCallbackExecuted();
-    void timeoutExecuteCloseCallback();
-    void closingAppProcessDidCrashed();
-    void didDispatchUnload();
 
 protected:
     // WebPageBase

--- a/src/core/WebPageObserver.h
+++ b/src/core/WebPageObserver.h
@@ -24,6 +24,14 @@ public:
     virtual void titleChanged() {}
     virtual void firstFrameVisuallyCommitted() {}
     virtual void navigationHistoryChanged() {}
+    virtual void webPageLoadFinished() {}
+    virtual void webPageLoadFailed(int errorCode) {}
+    virtual void closeCallbackExecuted() {}
+    virtual void timeoutExecuteCloseCallback() {}
+    virtual void closingAppProcessDidCrashed() {}
+    virtual void didDispatchUnload() {}
+    virtual void webPageClosePageRequested() {}
+    virtual void webViewRecreated() {}
 
 protected:
     WebPageObserver(WebPageBase* page);

--- a/src/platform/WebAppWayland.cpp
+++ b/src/platform/WebAppWayland.cpp
@@ -455,10 +455,6 @@ void WebAppWayland::doAttach()
         page()->setKeepAliveWebApp(keepAlive());
 
     setForceActivateVtgIfRequired();
-
-    connect(page(), SIGNAL(webPageClosePageRequested()), this, SLOT(webPageClosePageRequestedSlot()));
-    connect(page(), SIGNAL(webPageTitleChanged()), this, SLOT(webPageTitleChangedSlot()));
-    connect(page(), SIGNAL(webViewRecreated()), this, SLOT(webViewRecreatedSlot()));
 }
 
 void WebAppWayland::raise()
@@ -491,7 +487,7 @@ void WebAppWayland::goBackground()
     }
 }
 
-void WebAppWayland::webPageLoadFinishedSlot()
+void WebAppWayland::webPageLoadFinished()
 {
     if (getHiddenWindow())
         return;
@@ -512,7 +508,7 @@ void WebAppWayland::webPageLoadFinishedSlot()
     doPendingRelaunch();
 }
 
-void WebAppWayland::webPageLoadFailedSlot(int errorCode)
+void WebAppWayland::webPageLoadFailed(int errorCode)
 {
     // Do not load error page while preoload app launching.
     if (preloadState() != NONE_PRELOAD)
@@ -566,11 +562,6 @@ void WebAppWayland::showWindow()
     WebAppBase::showWindow();
 }
 
-void WebAppWayland::showWindowSlot()
-{
-    showWindow();
-}
-
 void WebAppWayland::titleChanged()
 {
     setWindowProperty(QStringLiteral("subtitle"), page()->title());
@@ -604,7 +595,7 @@ void WebAppWayland::navigationHistoryChanged()
     }
 }
 
-void WebAppWayland::webViewRecreatedSlot()
+void WebAppWayland::webViewRecreated()
 {
     m_appWindow->attachWebContents(page()->getWebContents());
     m_appWindow->RecreatedWebContents();

--- a/src/platform/WebAppWayland.h
+++ b/src/platform/WebAppWayland.h
@@ -50,8 +50,6 @@ public:
 };
 
 class WebAppWayland : public WebAppBase {
-    Q_OBJECT
-
 public:
     WebAppWayland(QString type, int surface_id, int width = 0, int height = 0);
     WebAppWayland(QString type, WebAppWaylandWindow* window, int width = 0, int height = 0);
@@ -121,11 +119,10 @@ protected:
     void moveInputRegion(int height);
     void setForceActivateVtgIfRequired();
 
-protected Q_SLOTS:
-    virtual void showWindowSlot();
-    virtual void webPageLoadFinishedSlot();
-    virtual void webPageLoadFailedSlot(int errorCode);
-    virtual void webViewRecreatedSlot();
+	// WebPageObserver
+    virtual void webPageLoadFailed(int errorCode);
+    virtual void webViewRecreated();
+    virtual void webPageLoadFinished();
 
 private:
     WebAppWaylandWindow* m_appWindow;

--- a/src/platform/webengine/WebPageBlink.cpp
+++ b/src/platform/webengine/WebPageBlink.cpp
@@ -49,10 +49,7 @@ QString getHostname(const std::string& url)
   return QUrl(q_url).host();
 }
 
-class WebPageBlinkPrivate : public QObject
-{
-    Q_OBJECT
-
+class WebPageBlinkPrivate {
 public:
     WebPageBlinkPrivate(WebPageBlink * page)
         : q(page)
@@ -621,7 +618,7 @@ void WebPageBlink::cleanResources()
 
 void WebPageBlink::close()
 {
-    Q_EMIT webPageClosePageRequested();
+    FOR_EACH_OBSERVER(WebPageObserver, m_observers, webPageClosePageRequested());
 }
 
 void WebPageBlink::didFirstFrameFocused()
@@ -649,7 +646,7 @@ void WebPageBlink::loadFinished(const std::string& url)
             PMLOGKFV("PID", "%d", getWebProcessPID()),
             "cleaningResources():true; (should be about:blank) emit 'didDispatchUnload'");
         // TODO: Remove QSignal
-        Q_EMIT didDispatchUnload();
+        FOR_EACH_OBSERVER(WebPageObserver, m_observers, didDispatchUnload());
         return;
     }
     handleLoadFinished();
@@ -669,7 +666,7 @@ void WebPageBlink::loadStopped(const std::string& url)
 
 void WebPageBlink::loadFailed(const std::string& url, int errCode, const std::string& errDesc)
 {
-    Q_EMIT webPageLoadFailed(errCode);
+    FOR_EACH_OBSERVER(WebPageObserver, m_observers, webPageLoadFailed(errCode));
 
     // We follow through only if we have SSL error
     if (errDesc != "SSL_ERROR")
@@ -723,7 +720,7 @@ void WebPageBlink::recreateWebView()
     }
 
     init();
-    Q_EMIT webViewRecreated();
+    FOR_EACH_OBSERVER(WebPageObserver, m_observers, webViewRecreated());
 
     if (!m_isSuspended) {
         // Remove white screen while reloading contents due to the renderer crash
@@ -767,7 +764,7 @@ void WebPageBlink::renderProcessCrashed()
         if (m_closeCallbackTimer.isRunning())
             m_closeCallbackTimer.stop();
 
-        Q_EMIT closingAppProcessDidCrashed();
+        FOR_EACH_OBSERVER(WebPageObserver, m_observers, closingAppProcessDidCrashed());
         return;
     }
 
@@ -775,10 +772,6 @@ void WebPageBlink::renderProcessCrashed()
     recreateWebView();
     if (!processCrashed())
         handleForceDeleteWebPage();
-}
-
-void WebPageBlink::didFinishLaunchingSlot()
-{
 }
 
 // functions from webappmanager2
@@ -948,7 +941,7 @@ void WebPageBlink::didRunCloseCallback()
 {
     m_closeCallbackTimer.stop();
     LOG_INFO(MSGID_WAM_DEBUG, 2, PMLOGKS("APP_ID", qPrintable(appId())), PMLOGKFV("PID", "%d", getWebProcessPID()), "WebPageBlink::didRunCloseCallback(); onclose callback done");
-    Q_EMIT closeCallbackExecuted();
+    FOR_EACH_OBSERVER(WebPageObserver, m_observers, closeCallbackExecuted());
 }
 
 void WebPageBlink::setHasOnCloseCallback(bool hasCloseCallback)
@@ -970,7 +963,7 @@ void WebPageBlink::timeoutCloseCallback()
 {
     m_closeCallbackTimer.stop();
     LOG_INFO(MSGID_WAM_DEBUG, 2, PMLOGKS("APP_ID", qPrintable(appId())), PMLOGKFV("PID", "%d", getWebProcessPID()), "WebPageBlink::timeoutCloseCallback(); onclose callback Timeout");
-    Q_EMIT timeoutExecuteCloseCallback();
+    FOR_EACH_OBSERVER(WebPageObserver, m_observers, timeoutExecuteCloseCallback());
 }
 
 void WebPageBlink::setFileAccessBlocked(bool blocked)
@@ -1165,6 +1158,4 @@ void WebPageBlink::setVisibilityState(WebPageVisibilityState visibilityState)
 bool WebPageBlink::allowMouseOnOffEvent() const {
     return false;
 }
-
-#include "WebPageBlink.moc"
 

--- a/src/platform/webengine/WebPageBlink.h
+++ b/src/platform/webengine/WebPageBlink.h
@@ -30,7 +30,6 @@ class BlinkWebView;
 class WebPageBlinkPrivate;
 
 class WebPageBlink : public WebPageBase, public WebPageBlinkDelegate {
-    Q_OBJECT
 public:
     enum FontRenderParams {
         HINTING_NONE = 0,
@@ -142,12 +141,6 @@ public:
     void resetStateToMarkNextPaintForContainer() override;
     void updateBackHistoryAPIDisabled();
 
-Q_SIGNALS:
-    void webPageClosePageRequested();
-    void webPageTitleChanged();
-    void webViewRecreated();
-    void moveInputRegion(qreal);
-
 protected:
     BlinkWebView* pageView() const;
 
@@ -169,9 +162,6 @@ protected:
     void handleBrowserControlFunction(const QString& command, const QStringList& arguments, QString* result) override;
 
     QString handleBrowserControlMessage(const QString& message, const QStringList& params);
-
-protected Q_SLOTS:
-    virtual void didFinishLaunchingSlot();
     virtual void suspendWebPagePaintingAndJSExecution();
 
 private:


### PR DESCRIPTION
**Change Description:**
- This PR drops Qt-specific signals/slots usage in WAM in favor of an Observer pattern based approach. Such mechanism is used to route WebView events between WebPage and WebApp objects.
- Assuming all events coming from underlying WebView implementation are called in the WAM main loop's thread, this observer-based approach should be equivalent to Qt-based signal/slot previous implementation.

**Verification status:**
- Build: Verified 
- Runtime/Regressions: Not verified yet** (@jdapena, Please help on this when you have some time)

** Not able to check on HW platforms (no HW available yet) nor using qemu builds, as [issue 1934](https://jira.automotivelinux.org/browse/SPEC-1934) is still blocking full WebApp lifecycle tests.

[[SPEC-1912]](https://jira.automotivelinux.org/browse/SPEC-1912)  Qt-less WAM: drop QObject + Q_SLOT + Q_SIGNALS
