### PR TITLE
Delete the webapp profile mapping when closed

### DIFF
--- a/src/core/WebAppManager.cpp
+++ b/src/core/WebAppManager.cpp
@@ -480,6 +480,8 @@ void WebAppManager::closeAppInternal(WebAppBase* app, bool ignoreCleanResource)
             app->dispatchUnload();
         }
     }
+
+    deleteWebViewProfile(app->appId().toStdString());
 }
 
 bool WebAppManager::closeAllApps(uint32_t pid)
@@ -1062,4 +1064,10 @@ void WebAppManager::buildWebViewProfile(const std::string& app_id, const std::st
 {
     if (m_webProcessManager)
         m_webProcessManager->buildWebViewProfile(app_id, proxy_rules);
+}
+
+void WebAppManager::deleteWebViewProfile(const std::string& app_id)
+{
+    if (m_webProcessManager)
+        m_webProcessManager->deleteWebViewProfile(app_id);
 }

--- a/src/core/WebAppManager.h
+++ b/src/core/WebAppManager.h
@@ -164,6 +164,7 @@ public:
     void clearBrowsingData(const int removeBrowsingDataMask);
     int maskForBrowsingDataType(const char* type);
     void buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules);
+    void deleteWebViewProfile(const std::string& app_id);
 
 protected:
 private:

--- a/src/core/WebProcessManager.h
+++ b/src/core/WebProcessManager.h
@@ -53,6 +53,7 @@ public:
     virtual void clearBrowsingData(const int removeBrowsingDataMask) = 0;
     virtual int maskForBrowsingDataType(const char* type) = 0;
     virtual void buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules) = 0;
+    virtual void deleteWebViewProfile(const std::string& app_id) = 0;
 
 protected:
     std::list<const WebAppBase*> runningApps();

--- a/src/platform/webengine/BlinkWebProcessManager.cpp
+++ b/src/platform/webengine/BlinkWebProcessManager.cpp
@@ -125,3 +125,8 @@ void BlinkWebProcessManager::buildWebViewProfile(const std::string& app_id, cons
 {
     BlinkWebViewProfileHelper::instance()->buildProfile(app_id, proxy_rules);
 }
+
+void BlinkWebProcessManager::deleteWebViewProfile(const std::string& app_id)
+{
+    BlinkWebViewProfileHelper::instance()->deleteProfile(app_id);
+}

--- a/src/platform/webengine/BlinkWebProcessManager.h
+++ b/src/platform/webengine/BlinkWebProcessManager.h
@@ -36,6 +36,7 @@ public:
     void clearBrowsingData(const int removeBrowsingDataMask) override;
     int maskForBrowsingDataType(const char* type) override;
     void buildWebViewProfile(const std::string& app_id, const std::string& proxy_rules) override;
+    void deleteWebViewProfile(const std::string& app_id) override;
 };
 
 #endif /* BLINKEBPROCESSMANAGER_H */

--- a/src/platform/webengine/BlinkWebViewProfileHelper.cpp
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.cpp
@@ -85,4 +85,13 @@ void BlinkWebViewProfileHelper::buildProfile(const std::string& app_id, const st
     webos::WebViewProfile* profile = new webos::WebViewProfile(app_id);
     profile->SetProxyRules(proxy_rules);
     m_appProfileMap[app_id] = profile;
+    fprintf(stderr, "BlinkWebViewProfileHelper: added WebViewProfile for app %s\n", app_id.c_str());
+}
+
+void BlinkWebViewProfileHelper::deleteProfile(const std::string& app_id)
+{
+    assert(m_appProfileMap.count(app_id) == 1);
+    delete m_appProfileMap[app_id];
+    m_appProfileMap.erase(app_id);
+    fprintf(stderr, "BlinkWebViewProfileHelper: removed WebViewProfile for app %s\n", app_id.c_str());
 }

--- a/src/platform/webengine/BlinkWebViewProfileHelper.h
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.h
@@ -49,6 +49,7 @@ public:
     static int maskForBrowsingDataType(const char* key);
     webos::WebViewProfile* getProfile(const std::string& app_id);
     void buildProfile(const std::string& app_id, const std::string& proxy_rules);
+    void deleteProfile(const std::string& app_id);
 
 private:
     BlinkWebViewProfileHelper() {}


### PR DESCRIPTION
When a webapp is closed, cleanup the WebViewProfile that was created to
store that particular webapp proxy rules.

[SPEC-1933] delete the WebViewProfile/proxy rules mapping when an app is closed
https://jira.automotivelinux.org/browse/SPEC-1933

This change cannot  be verified until we have support for closing apps.
cc @jdapena 