### PR TITLE
[agl] Fix linker issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ elseif(IS_AGL)
     pkg_search_module(LIBWM REQUIRED libwindowmanager)
     pkg_search_module(LIBHS REQUIRED libhomescreen)
     pkg_search_module(ILMCTRL REQUIRED ilmControl)
+    pkg_search_module(ILMCOMMON REQUIRED ilmCommon)
     list(APPEND WAM_COMMON_DEFINES HAS_AGL_SERVICE)
 endif()
 
@@ -304,6 +305,7 @@ set(WAM_EXE_INCLUDE_DIRS
 )
 set(WAM_EXE_LIBRARIES
     ${CHROMIUM_LDFLAGS}
+    ${ILMCOMMON_LDFLAGS}
     Boost::filesystem
     wamlib
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -307,6 +307,7 @@ set(WAM_EXE_LIBRARIES
     ${CHROMIUM_LDFLAGS}
     ${ILMCOMMON_LDFLAGS}
     Boost::filesystem
+    wamcorelib
     wamlib
 )
 set(WAM_EXE_LD_FLAGS -Wl,--no-as-needed)


### PR DESCRIPTION
These issues seem only be present in Halibut (current master):
```
libWebAppMgr.so: undefined reference to `ilm_init'
```
```
ld: warning: libWebAppMgrCore.so.1.0, needed by src/libWebAppMgr.so.1.0.0, not found (try using -rpath or -rpath-link)
ld: src/libWebAppMgr.so.1.0.0: undefined reference to `WebPageBase::handleLoadStarted()'
```

AGL-bug: [SPEC-2532](https://jira.automotivelinux.org/browse/SPEC-2532)