### PR TITLE
Apuentes/spec 2337 2328

### DIFF
--- a/src/core/WebAppManagerConfig.cpp
+++ b/src/core/WebAppManagerConfig.cpp
@@ -80,11 +80,20 @@ void WebAppManagerConfig::initConfiguration()
 
 void WebAppManagerConfig::postInitConfiguration()
 {
-    if (access("/var/luna/preferences/debug_system_apps", F_OK) == 0) {
+    std::string dir;
+#if defined(HAS_AGL_SERVICE)
+    dir = "/var/agl-devel/preferences/";
+#else
+    dir = "/var/luna/preferences/";
+#endif
+
+    std::string debug_apps_setting = dir + "debug_system_apps";
+    if (access(debug_apps_setting.c_str(), F_OK) == 0) {
         m_inspectorEnabled = true;
     }
 
-    if (access("/var/luna/preferences/devmode_enabled", F_OK) == 0) {
+    std::string devmode_setting = dir + "devmode_enabled";
+    if (access(devmode_setting.c_str(), F_OK) == 0) {
         m_devModeEnabled = true;
         m_telluriumNubPath = WebAppManagerUtils::getEnv("TELLURIUM_NUB_PATH");
     }

--- a/src/platform/webengine/WebPageBlink.cpp
+++ b/src/platform/webengine/WebPageBlink.cpp
@@ -889,11 +889,14 @@ void WebPageBlink::setPageProperties()
         d->pageView->SetTransparentBackground(true);
     }
 
-    // set inspectable
+#if defined(OS_WEBOS) || defined(AGL_DEVEL)
+    // Set inspectable. For AGL this feature is only available if the
+    // 'agl-devel' distro feature is on.
     if (m_appDesc->isInspectable() || inspectable()) {
         LOG_DEBUG("[%s] inspectable : true or 'debug_system_apps' mode; setInspectablePage(true)", appId().c_str());
         d->pageView->EnableInspectablePage();
     }
+#endif
 
     setTrustLevel(defaultTrustLevel());
     d->pageView->UpdatePreferences();
@@ -1091,8 +1094,10 @@ void WebPageBlink::deleteWebStorages(const std::string& identifier)
 
 void WebPageBlink::setInspectorEnable()
 {
+#if defined(OS_WEBOS) || defined(AGL_DEVEL)
     LOG_DEBUG("[%s] Inspector enable", appId().c_str());
     d->pageView->EnableInspectablePage();
+#endif
 }
 
 void WebPageBlink::setKeepAliveWebApp(bool keepAlive) {


### PR DESCRIPTION
Contains fixes for  the AGL spec-issues related to the remote inspector:
* [SPEC-2328] Update the path for Remote Web Inspector
* [SPEC-2327] Remote Debugging should work only on debug mode

