### PR TITLE
[agl] Suspend/resume webapps depending on visibility

### DIFF
--- a/src/agl/WebRuntimeAGL.cpp
+++ b/src/agl/WebRuntimeAGL.cpp
@@ -262,8 +262,16 @@ bool WebAppLauncherRuntime::init_wm() {
     return false;
   }
 
-  std::function< void(json_object*) > h_active = [this](json_object* object) {
+  std::function< void(json_object*) > h_active = [](json_object* object) {
     LOG_DEBUG("Got Event_Active");
+  };
+
+  std::function< void(json_object*) > h_inactive = [](json_object* object) {
+    LOG_DEBUG("Got Event_Inactive");
+  };
+
+  std::function< void(json_object*) > h_visible = [this](json_object* object) {
+    LOG_DEBUG("Got Event_Visible");
 
     std::vector<const char*> data;
     data.push_back(kActivateEvent);
@@ -272,22 +280,14 @@ bool WebAppLauncherRuntime::init_wm() {
     WebAppManagerServiceAGL::instance()->sendEvent(data.size(), data.data());
   };
 
-  std::function< void(json_object*) > h_inactive = [this](json_object* object) {
-    LOG_DEBUG("Got Event_Inactive");
+  std::function< void(json_object*) > h_invisible = [this](json_object* object) {
+    LOG_DEBUG("Got Event_Invisible");
 
     std::vector<const char*> data;
     data.push_back(kDeactivateEvent);
     data.push_back(this->m_id.c_str());
 
     WebAppManagerServiceAGL::instance()->sendEvent(data.size(), data.data());
-  };
-
-  std::function< void(json_object*) > h_visible = [](json_object* object) {
-    LOG_DEBUG("Got Event_Visible");
-  };
-
-  std::function< void(json_object*) > h_invisible = [](json_object* object) {
-    LOG_DEBUG("Got Event_Invisible");
   };
 
   std::function< void(json_object*) > h_syncdraw =


### PR DESCRIPTION
WAM is not receiving the Active/Inactive events from the Window
Manager when the webapp becomes visible/invisible so, react to the
Visible/Invisible events to resume/suspend the webapp instead.

AGL-bug: SPEC-1948

Signed-off-by: Antia Puentes <apuentes@igalia.com>