### PR TITLE
[agl] adapt to token logic and nss-localuser

### DIFF
--- a/src/agl/WebRuntimeAGL.cpp
+++ b/src/agl/WebRuntimeAGL.cpp
@@ -230,11 +230,21 @@ bool WebAppLauncherRuntime::init() {
       }
     }
 
+    bool url_misses_token = true;
     if (url_match_result.size() > 7) {
       std::string query = url_match_result[7].str();
       std::size_t n = query.find('=');
       if (n != std::string::npos) {
         m_token = query.substr(n+1);
+        url_misses_token = false;
+      }
+    }
+    if (url_misses_token) {
+      char *tokenv = getenv("CYNAGOAUTH_TOKEN");
+      if (tokenv) {
+        m_token = tokenv;
+        char intro = (url_match_result.size() > 7) ? '&' : '?';
+        m_url += intro + "token=" + m_token;
       }
     }
 

--- a/src/agl/WebRuntimeAGL.cpp
+++ b/src/agl/WebRuntimeAGL.cpp
@@ -224,9 +224,16 @@ bool WebAppLauncherRuntime::init() {
       std::size_t n = authority.find(':');
       if (n != std::string::npos) {
         std::string sport = authority.substr(n+1);
+        m_host = authority.substr(0, n);
+        m_role.append("-");
+        m_role.append(m_host);
         m_role.append("-");
         m_role.append(sport);
         m_port = stringTo<int>(sport);
+      } else {
+        m_host = authority;
+        m_role.append("-");
+        m_role.append(m_host);
       }
     }
 
@@ -257,9 +264,9 @@ bool WebAppLauncherRuntime::init() {
       return false;
     }
 
-    LOG_DEBUG("id=[%s], name=[%s], role=[%s], url=[%s], port=%d, token=[%s]",
+    LOG_DEBUG("id=[%s], name=[%s], role=[%s], url=[%s], host=[%s], port=%d, token=[%s]",
             m_id.c_str(), m_name.c_str(), m_role.c_str(), m_url.c_str(),
-            m_port, m_token.c_str());
+            m_host.c_str(), m_port, m_token.c_str());
 
     // Setup HomeScreen/WindowManager API
     if (!init_wm()) {
@@ -284,7 +291,7 @@ bool WebAppLauncherRuntime::init() {
 
 bool WebAppLauncherRuntime::init_wm() {
   m_wm = new LibWindowmanager();
-  if (m_wm->init(m_port, m_token.c_str())) {
+  if (m_wm->init(m_host.c_str(), m_port, m_token.c_str())) {
     LOG_DEBUG("cannot initialize windowmanager");
     return false;
   }
@@ -339,7 +346,7 @@ bool WebAppLauncherRuntime::init_wm() {
 
 bool WebAppLauncherRuntime::init_hs() {
   m_hs = new LibHomeScreen();
-  if (m_hs->init(m_port, m_token.c_str())) {
+  if (m_hs->init(m_host.c_str(), m_port, m_token.c_str())) {
     LOG_DEBUG("cannot initialize homescreen");
     return false;
   }

--- a/src/agl/WebRuntimeAGL.h
+++ b/src/agl/WebRuntimeAGL.h
@@ -88,6 +88,7 @@ private:
   std::string m_role;
   std::string m_url;
   std::string m_name;
+  std::string m_host;
 
   int m_port;
   std::string m_token;


### PR DESCRIPTION
Fallback to use the environment variable CYNAGOAUTH_TOKEN
if defined and if no token was provided in the URL.

Signed-off-by: José Bollo <jose.bollo@iot.bzh>