### PR TITLE
Hard-code windowmanager roles for certain app ids

### DIFF
--- a/src/agl/WebRuntimeAGL.cpp
+++ b/src/agl/WebRuntimeAGL.cpp
@@ -247,6 +247,12 @@ bool WebAppLauncherRuntime::init() {
       return false;
     }
 
+    // Special cases for windowmanager roles
+    if (m_id.rfind("webapps-html5-homescreen", 0) == 0)
+      m_role = "homescreen";
+    else if (m_id.rfind("webapps-homescreen", 0) == 0)
+      m_role = "homescreen";
+
     LOG_DEBUG("id=[%s], name=[%s], role=[%s], url=[%s], port=%d, token=[%s]",
             m_id.c_str(), m_name.c_str(), m_role.c_str(), m_url.c_str(),
             m_port, m_token.c_str());


### PR DESCRIPTION
Certain apps are required to have specific role names, so the window manager assigns them to the proper region. That would be the case of the homescreen.

This patch hard-codes the "homescreen" role to certain app ids. It's meant to be a temporary solution to be used with the legacy window manager, while the new one is not in place.

Bug-AGL: [SPEC-2401](https://jira.automotivelinux.org/browse/SPEC-2401)