### PR TITLE
Disable tinyproxy integration.

### DIFF
--- a/src/agl/WebAppManagerServiceAGL.cpp
+++ b/src/agl/WebAppManagerServiceAGL.cpp
@@ -178,8 +178,7 @@ public:
 
       if (std::string(res[0]) == kStartApp) {
         WebAppManagerServiceAGL::instance()->setStartupApplication(
-          std::string(res[1]), std::string(res[2]), atoi(res[3]),
-          std::string(res[4]));
+          std::string(res[1]), std::string(res[2]), atoi(res[3]));
 
         WebAppManagerServiceAGL::instance()->triggerStartupApp();
       } else {

--- a/src/agl/WebRuntimeAGL.cpp
+++ b/src/agl/WebRuntimeAGL.cpp
@@ -138,10 +138,6 @@ int SharedBrowserProcessWebAppLauncher::launch(const std::string& id, const std:
     return -1;
   }
 
-  tiny_proxy_ = std::make_unique<TinyProxy>();
-  int port = tiny_proxy_->port();
-  std::string proxy_port = std::to_string(port);
-
   m_rid = (int)getpid();
   std::string m_rid_s = std::to_string(m_rid);
   std::vector<const char*> data;
@@ -149,7 +145,6 @@ int SharedBrowserProcessWebAppLauncher::launch(const std::string& id, const std:
   data.push_back(id.c_str());
   data.push_back(uri.c_str());
   data.push_back(m_rid_s.c_str());
-  data.push_back(proxy_port.c_str());
 
   WebAppManagerServiceAGL::instance()->launchOnHost(data.size(), data.data());
   return m_rid;


### PR DESCRIPTION
With token-based logic in place (SPEC-2550), this would not be necessary. It is expected to reduce system complexity and increase performance. Besides, it serves as a workaround for SPEC-2900.

TODO: clean up all traces of Tinyproxy integration.

Bug-AGL: SPEC-2550
Bug-AGL: SPEC-2900