### PR TITLE
[agl] Delete the remains of tinyproxy

### DIFF
--- a/src/agl/WebAppManagerServiceAGL.cpp
+++ b/src/agl/WebAppManagerServiceAGL.cpp
@@ -238,13 +238,11 @@ void WebAppManagerServiceAGL::sendEvent(int argc, const char **argv)
 
 void WebAppManagerServiceAGL::setStartupApplication(
     const std::string& startup_app_id,
-    const std::string& startup_app_uri, int startup_app_surface_id,
-    const std::string& startup_proxy_port)
+    const std::string& startup_app_uri, int startup_app_surface_id)
 {
     startup_app_id_ = startup_app_id;
     startup_app_uri_ = startup_app_uri;
     startup_app_surface_id_ = startup_app_surface_id;
-    startup_proxy_port_ = startup_proxy_port;
 }
 
 void WebAppManagerServiceAGL::setAppIdForEventTarget(const std::string& app_id) {
@@ -396,11 +394,6 @@ void WebAppManagerServiceAGL::launchStartupAppFromURL()
     std::string params, errMsg;
 
     LOG_DEBUG("Launching with appDesc=[%s]", appDesc.c_str());
-
-    if (!startup_proxy_port_.empty()) {
-        WebAppManagerService::buildWebViewProfile(app_id, "localhost", startup_proxy_port_);
-        LOG_DEBUG("buildWebViewProfile: Done.");
-    }
 
     WebAppManagerService::onLaunch(appDesc, params, app_id, errCode, errMsg);
     LOG_DEBUG("onLaunch: Done.");

--- a/src/agl/WebAppManagerServiceAGL.h
+++ b/src/agl/WebAppManagerServiceAGL.h
@@ -23,8 +23,7 @@ public:
     bool isHostServiceRunning();
 
     void setStartupApplication(const std::string& startup_app_id,
-        const std::string& startup_app_uri, int startup_app_surface_id,
-        const std::string& startup_proxy_port =  std::string());
+        const std::string& startup_app_uri, int startup_app_surface_id);
     void setAppIdForEventTarget(const std::string& app_id);
 
     void launchOnHost(int argc, const char **argv);
@@ -61,7 +60,6 @@ private:
 
     std::string startup_app_id_;
     std::string startup_app_uri_;
-    std::string startup_proxy_port_;
     int startup_app_surface_id_;
     OneShotTimer<WebAppManagerServiceAGL> startup_app_timer_;
 

--- a/src/agl/WebRuntimeAGL.cpp
+++ b/src/agl/WebRuntimeAGL.cpp
@@ -1,10 +1,7 @@
 #include "WebRuntimeAGL.h"
 
 #include <cassert>
-#include <netinet/in.h>
 #include <regex>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <unistd.h>
 
 #include <glib.h>
@@ -521,23 +518,3 @@ int WebRuntimeAGL::run(int argc, const char** argv) {
   return m_runtime->run(argc, argv);
 }
 
-TinyProxy::TinyProxy() {
-  // Get a free port to listen
-  int test_socket = socket(AF_INET, SOCK_STREAM, 0);
-  struct sockaddr_in test_socket_addr;
-  memset(&test_socket_addr, 0, sizeof(test_socket_addr));
-  test_socket_addr.sin_port = htons(0);
-  test_socket_addr.sin_family = AF_INET;
-  bind(test_socket, (struct sockaddr*) &test_socket_addr, sizeof(struct sockaddr_in));
-  socklen_t len = sizeof(test_socket_addr);
-  getsockname(test_socket, (struct sockaddr*) &test_socket_addr, &len);
-  int port = ntohs(test_socket_addr.sin_port);
-  close(test_socket);
-
-  setPort(port);
-
-  std::string cmd = "tinyproxy -p " + std::to_string(port);
-  int res = std::system(cmd.data());
-  if (res == -1)
-    LOG_DEBUG("Error while running %s", cmd.data());
-}

--- a/src/agl/WebRuntimeAGL.h
+++ b/src/agl/WebRuntimeAGL.h
@@ -2,7 +2,6 @@
 #define WEBRUNTIME_AGL_H
 
 #include <unordered_map>
-#include <memory>
 #include <signal.h>
 #include <string>
 #include <unordered_map>
@@ -41,22 +40,10 @@ public:
   std::unordered_map<pid_t, pid_t> m_pid_map; // pair of <app_pid, pid which creates a surface>
 };
 
-class TinyProxy {
- public:
-  int port() { return port_; }
-  void setPort(int port) { port_ = port; }
-
-  TinyProxy();
-private:
-  int port_;
-};
-
 class SharedBrowserProcessWebAppLauncher : public Launcher {
 public:
   int launch(const std::string& id, const std::string& uri) override;
   int loop(int argc, const char** argv, volatile sig_atomic_t& e_flag) override;
-private:
-  std::unique_ptr<TinyProxy> tiny_proxy_;
 };
 
 class SingleBrowserProcessWebAppLauncher : public Launcher {

--- a/src/core/WebAppManager.cpp
+++ b/src/core/WebAppManager.cpp
@@ -482,8 +482,6 @@ void WebAppManager::closeAppInternal(WebAppBase* app, bool ignoreCleanResource)
             app->dispatchUnload();
         }
     }
-
-    deleteWebViewProfile(app->appId());
 }
 
 bool WebAppManager::closeAllApps(uint32_t pid)
@@ -1087,16 +1085,4 @@ void WebAppManager::clearBrowsingData(const int removeBrowsingDataMask)
 int WebAppManager::maskForBrowsingDataType(const char* type)
 {
     return m_webProcessManager->maskForBrowsingDataType(type);
-}
-
-void WebAppManager::buildWebViewProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port)
-{
-    if (m_webProcessManager)
-        m_webProcessManager->buildWebViewProfile(app_id, proxy_host, proxy_port);
-}
-
-void WebAppManager::deleteWebViewProfile(const std::string& app_id)
-{
-    if (m_webProcessManager)
-        m_webProcessManager->deleteWebViewProfile(app_id);
 }

--- a/src/core/WebAppManager.h
+++ b/src/core/WebAppManager.h
@@ -161,8 +161,6 @@ public:
 
     void clearBrowsingData(const int removeBrowsingDataMask);
     int maskForBrowsingDataType(const char* type);
-    void buildWebViewProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port);
-    void deleteWebViewProfile(const std::string& app_id);
 
 protected:
 private:

--- a/src/core/WebAppManagerService.cpp
+++ b/src/core/WebAppManagerService.cpp
@@ -226,8 +226,3 @@ int WebAppManagerService::maskForBrowsingDataType(const char* type)
 {
     return WebAppManager::instance()->maskForBrowsingDataType(type);
 }
-
-void WebAppManagerService::buildWebViewProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port)
-{
-    WebAppManager::instance()->buildWebViewProfile(app_id, proxy_host, proxy_port);
-}

--- a/src/core/WebAppManagerService.h
+++ b/src/core/WebAppManagerService.h
@@ -84,7 +84,6 @@ protected:
     Json::Value closeByInstanceId(const std::string& instanceId);
     int maskForBrowsingDataType(const char* type);
     void onClearBrowsingData(const int removeBrowsingDataMask);
-    void buildWebViewProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port);
 
     WebAppBase* getContainerApp();
 #ifndef PRELOADMANAGER_ENABLED

--- a/src/core/WebProcessManager.h
+++ b/src/core/WebProcessManager.h
@@ -50,8 +50,6 @@ public:
     virtual uint32_t getInitialWebViewProxyID() const = 0;
     virtual void clearBrowsingData(const int removeBrowsingDataMask) = 0;
     virtual int maskForBrowsingDataType(const char* type) = 0;
-    virtual void buildWebViewProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port) = 0;
-    virtual void deleteWebViewProfile(const std::string& app_id) = 0;
 
 protected:
     std::list<const WebAppBase*> runningApps();

--- a/src/platform/webengine/BlinkWebProcessManager.cpp
+++ b/src/platform/webengine/BlinkWebProcessManager.cpp
@@ -118,12 +118,3 @@ int BlinkWebProcessManager::maskForBrowsingDataType(const char* type)
 {
     return BlinkWebViewProfileHelper::maskForBrowsingDataType(type);
 }
-
-void BlinkWebProcessManager::buildWebViewProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port) {
-    BlinkWebViewProfileHelper::instance()->buildProfile(app_id, proxy_host, proxy_port);
-}
-
-void BlinkWebProcessManager::deleteWebViewProfile(const std::string& app_id)
-{
-    BlinkWebViewProfileHelper::instance()->deleteProfile(app_id);
-}

--- a/src/platform/webengine/BlinkWebProcessManager.h
+++ b/src/platform/webengine/BlinkWebProcessManager.h
@@ -34,8 +34,6 @@ public:
     uint32_t getInitialWebViewProxyID() const override;
     void clearBrowsingData(const int removeBrowsingDataMask) override;
     int maskForBrowsingDataType(const char* type) override;
-    void buildWebViewProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port) override;
-    void deleteWebViewProfile(const std::string& app_id) override;
 };
 
 #endif /* BLINKEBPROCESSMANAGER_H */

--- a/src/platform/webengine/BlinkWebViewProfileHelper.cpp
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.cpp
@@ -22,11 +22,6 @@
 #include <cassert>
 #include <cstring>
 
-BlinkWebViewProfileHelper* BlinkWebViewProfileHelper::instance() {
-    static BlinkWebViewProfileHelper* sInstance = new BlinkWebViewProfileHelper();
-    return sInstance;
-}
-
 void BlinkWebViewProfileHelper::clearBrowsingData(const int removeBrowsingDataMask,
         webos::WebViewProfile *profile)
 {
@@ -71,27 +66,4 @@ int BlinkWebViewProfileHelper::maskForBrowsingDataType(const char* type) {
         return webos::WebViewProfile::REMOVE_WEBSQL;
 
     return 0;
-}
-
-webos::WebViewProfile* BlinkWebViewProfileHelper::getProfile(const std::string& app_id) {
-    if (m_appProfileMap.find(app_id) == m_appProfileMap.end())
-       return nullptr;
-    return m_appProfileMap[app_id];
-}
-
-void BlinkWebViewProfileHelper::buildProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port)
-{
-    assert(m_appProfileMap.count(app_id) == 0);
-    webos::WebViewProfile* profile = new webos::WebViewProfile(app_id);
-    profile->SetProxyServer(proxy_host, proxy_port, {}, {});
-    m_appProfileMap[app_id] = profile;
-    fprintf(stderr, "BlinkWebViewProfileHelper: added WebViewProfile for app %s\n", app_id.c_str());
-}
-
-void BlinkWebViewProfileHelper::deleteProfile(const std::string& app_id)
-{
-    assert(m_appProfileMap.count(app_id) == 1);
-    delete m_appProfileMap[app_id];
-    m_appProfileMap.erase(app_id);
-    fprintf(stderr, "BlinkWebViewProfileHelper: removed WebViewProfile for app %s\n", app_id.c_str());
 }

--- a/src/platform/webengine/BlinkWebViewProfileHelper.h
+++ b/src/platform/webengine/BlinkWebViewProfileHelper.h
@@ -17,7 +17,6 @@
 #ifndef BLINK_WEB_VIEW_PROFILE_HELPER_H_
 #define BLINK_WEB_VIEW_PROFILE_HELPER_H_
 
-#include <unordered_map>
 #include <string>
 
 namespace webos {
@@ -41,21 +40,13 @@ const char kWebSQL[] = "webSQL";
 
 class BlinkWebViewProfileHelper {
 public:
-    static BlinkWebViewProfileHelper* instance();
+    BlinkWebViewProfileHelper() {}
+    virtual ~BlinkWebViewProfileHelper() {}
 
     static void clearBrowsingData(const int removeBrowsingDataMask,
         webos::WebViewProfile* profile = nullptr);
     static void clearDefaultBrowsingData(const int removeBrowsingDataMask);
     static int maskForBrowsingDataType(const char* key);
-    webos::WebViewProfile* getProfile(const std::string& app_id);
-    void buildProfile(const std::string& app_id, const std::string& proxy_host, const std::string& proxy_port);
-    void deleteProfile(const std::string& app_id);
-
-private:
-    BlinkWebViewProfileHelper() {}
-    virtual ~BlinkWebViewProfileHelper() = default;
-
-    std::unordered_map<std::string, webos::WebViewProfile*> m_appProfileMap;
 };
 
 #endif // BLINK_WEB_VIEW_PROFILE_HELPER_H_

--- a/src/platform/webengine/WebPageBlink.cpp
+++ b/src/platform/webengine/WebPageBlink.cpp
@@ -29,7 +29,6 @@
 #include "ApplicationDescription.h"
 #include "BlinkWebProcessManager.h"
 #include "BlinkWebView.h"
-#include "BlinkWebViewProfileHelper.h"
 #include "LogManager.h"
 #include "PalmSystemBlink.h"
 #include "StringUtils.h"
@@ -38,8 +37,6 @@
 #include "WebAppManagerUtils.h"
 #include "WebPageObserver.h"
 #include "WebPageBlinkObserver.h"
-
-#include "webos/webview_profile.h"
 
 #define DBG(fmt, ...)                           \
     do {                                        \
@@ -107,11 +104,6 @@ void WebPageBlink::init()
 {
     d->pageView = createPageView();
     d->pageView->setDelegate(this);
-    webos::WebViewProfile* profile = BlinkWebViewProfileHelper::instance()->getProfile(m_appDesc->id());
-    if (profile) {
-        DBG("### Setting profile for page %s\n", m_appDesc->id().c_str());
-        d->pageView->SetProfile(profile->GetProfileDelegate());
-    }
     d->pageView->Initialize(m_appDesc->id(),
                             m_appDesc->folderPath(),
                             m_appDesc->trustLevel(),


### PR DESCRIPTION
Since commit a9e009347be183b1b880243151a2242f2f6c59b9 tinyproxy is not
used anymore.

This patch deletes the dead tinyproxy code and the WebViewProfile as,
without tinyproxy, a different WebViewProfile per webapplication is no
longer needed and we can go back to use the default profile (related
to commit 58ce0013d8f41d1a5d75eefc4f3bbef1e0317da8).

Bug-AGL: SPEC-3185

Signed-off-by: Antia Puentes <apuentes@igalia.com>