### PR TITLE
wam: Fix outbound permission error

### DIFF
--- a/files/sysbus/com.palm.webappmanager.perm.json
+++ b/files/sysbus/com.palm.webappmanager.perm.json
@@ -22,6 +22,7 @@
     "com.webos.settingsservice.client-*": [
         "application.launcher",
         "application.operation",
-        "settings.query"
+        "settings.query",
+        "networkconnection.query"
     ]
 }


### PR DESCRIPTION
Fixes: Apr 11 22:05:24 qemux86-64 webos-connman-adapter[1266]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"CLIENT":"com.webos.settingsservice.client-1136","SERVICE":"com.webos.service.connectionmanager","CATEGORY":"/","METHOD":"getStatus"} Service security groups don't allow method call.

Might be a partial solution for YouTube not working in recent releases.